### PR TITLE
Enable Prophecy by default and fix environment in test run

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,10 @@
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
+        <!-- See: https://symfony.com/doc/current/components/phpunit_bridge.html#modified-phpunit-script -->
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <!-- Set "SYMFONY_PHPUNIT_REMOVE" to "symfony/yaml" will install also "prophecy" see phpunit bridge docs for more information. -->
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="symfony/yaml"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,8 +9,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="APP_ENV" value="test" />
-        <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Explain the contents of the PR.

#### Why?

Tests should not run accidently in false environment.

See:
https://github.com/symfony/recipes/blob/master/phpunit/phpunit/4.7/phpunit.xml.dist#L12

#### Example Usage

```php
APP_ENV=dev vendor/bin/phpunit
```
