### PR TITLE
Remove dev version of MassiveSearchBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "doctrine/doctrine-fixtures-bundle": "~2.4",
         "friendsofsymfony/http-cache-bundle": "~2.3",
         "jackalope/jackalope-doctrine-dbal": "^1.3.0",
-        "massive/search-bundle": "dev-develop",
         "sulu/sulu": "dev-develop",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dotenv": "^3.4 || ^4.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | depends on sulu/sulu#4783
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the dev dependency to the MassiveSearchBundle.