### PR TITLE
Improve required php extensions and polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require": {
         "php": "^7.2",
+        "ext-ctype": "*",
         "ext-iconv": "*",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/doctrine-bundle": "^1.10",
@@ -66,8 +67,10 @@
         }
     },
     "replace": {
+        "paragonie/random_compat": "2.*",
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php72": "*",
         "symfony/polyfill-php71": "*",
         "symfony/polyfill-php70": "*",
         "symfony/polyfill-php56": "*"

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,1 +1,1 @@
-# Define website routes in `routes_admin.yaml` and admin routes in the `routes_website.yaml`
+# Define website routes in `routes_website.yaml` and admin routes in the `routes_admin.yaml`


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add `ext-ctype` because its required by symfony see https://github.com/symfony/skeleton/blob/v4.3.99/composer.json#L8-L9
Add replace of `symfony/polyfill-php72` because php 7.2 is min version.

Add replace of `"paragonie/random_compat": "2.*",` because symfony skeleton: https://github.com/symfony/skeleton/blob/v4.3.99/composer.json#L37

Fix comment in routes.yaml.

#### Why?

Keep in sync with symfony/skeleton and because our min php version is php 7.2.

