### PR TITLE
Ignore symfony.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 # composer
 /composer.phar
 composer.lock
+symfony.lock
 /vendor
 
 # npm


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR ignores the `symfony.lock` file in git.

#### Why?

Because we don't want to fixate versions in `sulu/skeleton`.