### PR TITLE
Use new syntax for seo twig extension

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% block meta %}
-        {% include "SuluWebsiteBundle:Extension:seo.html.twig" with {
+        {% include "@SuluWebsite/Extension/seo.html.twig" with {
             "seo": extension.seo|default([]),
             "content": content|default([]),
             "urls": urls|default([]),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | sulu/sulu#4869
| License | MIT
| Documentation PR | -

#### What's in this PR?

Use new syntax for seo twig extension.

#### Why?

Allows to use sulu without the symfony/templating package which is deprecated and was removed in symfony 5.0
