### PR TITLE
Fix import of tag as type rest

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -1,5 +1,6 @@
 sulu_tag_api:
     resource: "@SuluTagBundle/Resources/config/routing_api.yml"
+    type: rest
     prefix:   /admin/api
 
 sulu_admin:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix import of tag as type rest.

#### Why?

Routes containing type rest routes should be imported as type rest.
Strangely it is set correctl in the sulu/sulu package:

https://github.com/sulu/sulu/blob/ade35fff4cb8ced777c726dcb730c5c5f5720960/config/routes/sulu_admin.yaml#L2