### PR TITLE
Add cache providers for phpcr metadata and nodes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     DATABASE_COLLATE: utf8mb4_unicode_ci
     NODEJS_VERSION: "12"
     matrix:
-        - PHP_VERSION: 7.2.4
+        - PHP_VERSION: 7.2.5
 
 services:
     - mysql

--- a/config/packages/prod/sulu_document_manager.yaml
+++ b/config/packages/prod/sulu_document_manager.yaml
@@ -1,0 +1,49 @@
+sulu_document_manager:
+    sessions:
+        default:
+            backend:
+                caches:
+                    meta: doctrine_phpcr.meta_cache_provider
+                    nodes: doctrine_phpcr.nodes_cache_provider
+        live:
+            backend:
+                caches:
+                    meta: doctrine_phpcr.meta_cache_provider_live
+                    nodes: doctrine_phpcr.nodes_cache_provider_live
+
+services:
+    doctrine_phpcr.meta_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.meta_cache_pool'
+
+    doctrine_phpcr.nodes_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.nodes_cache_pool'
+
+    doctrine_phpcr.meta_cache_provider_live:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.meta_cache_pool_live'
+
+    doctrine_phpcr.nodes_cache_provider_live:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.nodes_cache_pool_live'
+
+framework:
+    cache:
+        pools:
+            doctrine_phpcr.meta_cache_pool:
+                adapter: cache.app
+            doctrine_phpcr.nodes_cache_pool:
+                adapter: cache.app
+            doctrine_phpcr.meta_cache_pool_live:
+                adapter: cache.app
+            doctrine_phpcr.nodes_cache_pool_live:
+                adapter: cache.app

--- a/config/packages/stage/sulu_document_manager.yaml
+++ b/config/packages/stage/sulu_document_manager.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: '../prod/sulu_document_manager.yaml' }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Provide configuration for metadata and nodes cache provider.

#### Why?

To have caches for metadata and nodes under prod and stage environment. Inspired by recommended doctrine phpcr configuration: https://github.com/symfony/recipes-contrib/blob/ddc07bebb374d5bc332758d438972498b60c82f6/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/prod/doctrine_phpcr_dbal.yaml

#### To Do

- [ ] Create a documentation PR
- [ ] Create PR for sulu/sulu test skeleton
