### PR TITLE
Add context based annotations route configuration

### DIFF
--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,3 +1,1 @@
-controllers:
-    resource: ../../src/Controller/
-    type: annotation
+# Annotation are defined per context in "annotations_admin.yaml" and "annotations_website.yaml"

--- a/config/routes/annotations_admin.yaml
+++ b/config/routes/annotations_admin.yaml
@@ -1,0 +1,3 @@
+controllers:
+    resource: ../../src/Controller/Admin/
+    type: annotation

--- a/config/routes/annotations_website.yaml
+++ b/config/routes/annotations_website.yaml
@@ -1,0 +1,3 @@
+controllers:
+    resource: ../../src/Controller/Website/
+    type: annotation


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

So the routes are only registered in the context they are really used.

#### Why?

If for example a route does `/{locale}/{company}/contacts` this does also match `/admin/api/contacts`. And so will override the admin route.

#### To Do

- [ ] Create a documentation PR
- [ ] Create PR for sulu/sulu test skeleton TODO
