### PR TITLE
Remove web-server-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
         "symfony/error-handler": "^4.4",
         "symfony/phpunit-bridge": "^4.3",
         "symfony/thanks": "^1.1",
-        "symfony/web-profiler-bundle": "^4.3",
-        "symfony/web-server-bundle": "^4.3"
+        "symfony/web-profiler-bundle": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -35,7 +35,6 @@ return [
     DTL\Bundle\PhpcrMigrations\PhpcrMigrationsBundle::class => ['all' => true],
     Massive\Bundle\BuildBundle\MassiveBuildBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['dev' => true, 'test' => true],
     Sulu\Bundle\TestBundle\SuluTestBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true, 'admin' => true],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/5187
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove symfony/web-server-bundle.

#### Why?

The web server bundle is deprecated instead the internal php server or symfony cli should be used.
