### PR TITLE
Remove the path attribute from twig templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "friendsofsymfony/http-cache-bundle": "^2.8",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
-        "sulu/sulu": "~2.2.0",
+        "sulu/sulu": "~2.3.0 || ^2.3@dev",
         "symfony/config": "^5.1",
         "symfony/dotenv": "^5.1",
         "symfony/flex": "^1.2",

--- a/config/packages/sulu_website.yaml
+++ b/config/packages/sulu_website.yaml
@@ -2,3 +2,4 @@ sulu_website:
     twig:
         attributes:
             urls: false
+            path: false


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/5273
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove the path attribute from twig templates.

#### Why?

The `path` get mostly be confused by the `url` and so should be removed from the twig side. This effects the StructureResolver (page data) and the ContentMapper (smart content, page selection, navigation). 

#### To Do

- [ ] Create a documentation PR
- [ ] Create PR for sulu/sulu test skeleton
