### PR TITLE
Fix removable of lock files from gitignore after composer create-project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,8 +94,7 @@
             "php -r \"file_put_contents('.env', str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
         ],
         "post-create-project-cmd": [
-            "Sulu\\Bundle\\CoreBundle\\Composer\\ScriptHandler::removeComposerLockFromGitIgnore",
-            "Sulu\\Bundle\\CoreBundle\\Composer\\ScriptHandler::removePackageLockJsonFromGitIgnore"
+            "php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\""
         ]
     },
     "config": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | sulu/sulu#5307
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the removal of the lock files from gitignore.

#### Why?

The lock files should not be commited to the `skeleton` repository. But they should be added in a individual project, therefore we remove these lockfiles after a `create-project` call. Recently an error like the following happened:

```bash
Class Sulu\Bundle\CoreBundle\Composer\ScriptHandler is not autoloadable, can not call post-create-project-cmd script
Class Sulu\Bundle\CoreBundle\Composer\ScriptHandler is not autoloadable, can not call post-create-project-cmd script
```

This PR should prevent that from happening, and the lockfiles should be correctly removed from the `.gitignore` file.