### PR TITLE
Fix composer 2 compatibility for php 7.3 and lower

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,13 @@
         "php": "^7.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "composer/package-versions-deprecated": "^1.8",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/doctrine-bundle": "^1.10",
         "doctrine/doctrine-cache-bundle": "^1.3.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "friendsofsymfony/http-cache-bundle": "^2.6",
+        "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "sulu/sulu": "^2.0.8",
         "symfony/config": "^4.3",
@@ -44,8 +46,7 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/security-bundle": "^4.4",
         "symfony/swiftmailer-bundle": "^3.1.4",
-        "symfony/twig-bundle": "^4.3",
-        "handcraftedinthealps/zendsearch": "^2.0"
+        "symfony/twig-bundle": "^4.3"
     },
     "require-dev": {
         "phpcr/phpcr-shell": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | sulu/sulu#5357
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Require https://github.com/composer/package-versions-deprecated.

#### Why?

Fix composer 2 compatibility for php 7.3 and lower.

Alternative sulu/sulu#5357 the advantage here is that the project owner can removed it when they want to use the original ocramius package in php 7.4.
