### PR TITLE
Remove deprecated urls variable from twig template

### DIFF
--- a/config/packages/sulu_website.yaml
+++ b/config/packages/sulu_website.yaml
@@ -1,0 +1,4 @@
+sulu_website:
+    twig:
+        attributes:
+            urls: false

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -9,7 +9,7 @@
         {% include "@SuluWebsite/Extension/seo.html.twig" with {
             "seo": extension.seo|default([]),
             "content": content|default([]),
-            "urls": urls|default([]),
+            "localizations": localizations|default([]),
             "shadowBaseLocale": shadowBaseLocale|default(),
             "defaultLocale": app.request.locale
         } %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | sulu/sulu#5361
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR removes the deprecated `urls` variable from new skeleton applications.

#### Why?

Because the variable has been deprecated in sulu/sulu#5361, and should not be used anymore in new projects.

#### BC Breaks/Deprecations

The `urls` variable is not passed anymore to the twig templates.

#### ToDo

- [x] Fix call of seo template