### PR TITLE
Symlink assets if possible instead of hard copy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd",
+            "assets:install %PUBLIC_DIR% --symlink --relative": "symfony-cmd",
             "bin/websiteconsole cache:clear": "php-script",
             "bin/adminconsole sulu:media:init": "php-script",
             "bin/adminconsole massive:search:init": "php-script"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Symlink assets if possible instead of hard copy.

#### Why?

Avoid running assets:install when third party assets changed.

#### BC Breaks/Deprecations

No, if symlink is not possible symfony will since 2.6 fallback to hard copies.
