### PR TITLE
Require matching sulu version in skeleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
-        "sulu/sulu": "^2.0.9",
+        "sulu/sulu": "~2.0.9",
         "symfony/config": "^4.3",
         "symfony/dotenv": "^4.3",
         "symfony/flex": "^1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Require matching sulu version in skeleton.

#### Why?

When you switch to origin/release/2.0 branch you currently will get 2.1 and sometimes incompatible versions. I think we should use `~2.0.9`. This make it easier to install sulu at older specific older version.

Also somebody will not accidentally upgrade from `2.1` to `2.2` which I think is good as they should check the  UPGRADE.md then I think its good that they need first run `composer require sulu/sulu:"~2.1.0" --no-update && composer update` when they want to update.

#### To Do

- [ ] Create a documentation PR (should w
