### PR TITLE
Add user context based cache configuration

### DIFF
--- a/config/packages/fos_http_cache.yaml
+++ b/config/packages/fos_http_cache.yaml
@@ -4,7 +4,8 @@ fos_http_cache:
             use_kernel_dispatcher: true
 
 # activate the following for user context based caching
+# see https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
+# for additional needed changes
 #    user_context:
 #        enabled: true
 #        role_provider: true
-#        hash_cache_ttl: 3600 # should be increased

--- a/config/packages/fos_http_cache.yaml
+++ b/config/packages/fos_http_cache.yaml
@@ -4,8 +4,10 @@ fos_http_cache:
             use_kernel_dispatcher: true
 
 # activate the following for user context based caching
-# see https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
-# for additional needed changes
+# also activate the route in config/routes/fos_http_cache.yaml and subscriber in src/Kernel.php
+# see also: https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
+#
 #    user_context:
 #        enabled: true
 #        role_provider: true
+#        hash_cache_ttl: 0

--- a/config/packages/fos_http_cache.yaml
+++ b/config/packages/fos_http_cache.yaml
@@ -2,3 +2,9 @@ fos_http_cache:
     proxy_client:
         symfony:
             use_kernel_dispatcher: true
+
+# activate the following for user context based caching
+#    user_context:
+#        enabled: true
+#        role_provider: true
+#        hash_cache_ttl: 3600 # should be increased

--- a/config/packages/fos_rest.yaml
+++ b/config/packages/fos_rest.yaml
@@ -1,3 +1,6 @@
 fos_rest:
     zone:
         - { path: ^/admin/* }
+    format_listener:
+        rules:
+            - { path: ^/_fos_user_context_hash, stop: true }

--- a/config/packages/fos_rest.yaml
+++ b/config/packages/fos_rest.yaml
@@ -1,6 +1,3 @@
 fos_rest:
     zone:
         - { path: ^/admin/* }
-    format_listener:
-        rules:
-            - { path: ^/_fos_user_context_hash, stop: true }

--- a/config/packages/security_website.yaml
+++ b/config/packages/security_website.yaml
@@ -1,1 +1,27 @@
 # To enable security bundle for website you need to change `config/bundles.php` file
+#security:
+#    encoders:
+#        Sulu\Bundle\SecurityBundle\Entity\User: bcrypt
+#
+#    providers:
+#        sulu:
+#            id: sulu_security.user_provider
+#
+#    firewalls:
+#        sulu-test:
+#            pattern: ^/
+#            anonymous: lazy
+#            form_login:
+#                login_path: login # this route need to exist be created
+#                check_path: login
+#            logout:
+#                path: logout
+#                target: /
+#            remember_me:
+#                secret:   "%kernel.secret%"
+#                lifetime: 604800 # 1 week in seconds
+#                path:     /
+#
+#sulu_security:
+#    checker:
+#        enabled: true

--- a/config/packages/security_website.yaml
+++ b/config/packages/security_website.yaml
@@ -8,11 +8,14 @@
 #            id: sulu_security.user_provider
 #
 #    firewalls:
-#        sulu-test:
+#        website:
 #            pattern: ^/
 #            anonymous: lazy
+#            # The login and logout routes need to be created.
+#            # For an advanced user management with registration and opt-in emails have a look at the:
+#            # https://github.com/sulu/SuluCommunityBundle
 #            form_login:
-#                login_path: login # this route need to exist be created
+#                login_path: login
 #                check_path: login
 #            logout:
 #                path: logout

--- a/config/routes/fos_http_cache.yaml
+++ b/config/routes/fos_http_cache.yaml
@@ -1,0 +1,4 @@
+# activate the following for user context based caching
+# see https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
+#user_context_hash:
+#    path: /_fos_user_context_hash

--- a/config/routes_website.yaml
+++ b/config/routes_website.yaml
@@ -3,3 +3,18 @@
 #static:
 #    path: /static-route
 #    controller: App\Controller\DefaultController::index
+
+# If you have a simple login on your website activate the following routes
+# If you need registration or profile edit have a look at the:
+# https://github.com/sulu/SuluCommunityBundle
+#
+#login:
+#    path: /login
+#    controller:   Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+#    defaults:
+#        # the following template need to be created:
+#        # see https://github.com/sulu/sulu/blob/master/templates/static/login.html.twig as example
+#        template: static/login.html.twig
+#
+#logout:
+#    path: /logout

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -36,6 +36,14 @@ class Kernel extends SuluKernel implements HttpCacheProvider
     {
         if (!$this->httpCache) {
             $this->httpCache = new SuluHttpCache($this);
+            // Activate the following for user based caching see also:
+            // https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
+            //
+            //$this->httpCache->addSubscriber(
+            //    new \FOS\HttpCache\SymfonyCache\UserContextListener([
+            //        'session_name_prefix' => 'SULUSESSID',
+            //    ])
+            //);
         }
 
         return $this->httpCache;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add user context based cache configuration.

#### Why?

Because we want to write user based cache entries.

#### Example Usage

Add a login to the Website and activate security there with user context based caching:

Add following to your `base.html.twig`:

```twig
    <div style="background: red; padding: 10px; color: white; font-weight: bold;font-family: monospace;">
        Roles ({{ 'now'|date('Y-m-d H:i:s') -}}):
        {%- for role in app.token.roleNames %}
            {#- #} {{ role }}{% if not loop.last %},{% endif -%}
        {%- endfor -%}
        ;
    </div>
```

When not using `use_kernel_dispatcher` of the symfony cache (e.g. Using Varnish) then also a additional Route is needed:

```yaml
user_context_hash:
    path: /_fos_user_context_hash
```

#### To Do

- [ ] Create a documentation PR
- [x] Create PR for sulu/sulu test skeleton https://github.com/sulu/sulu/pull/5443
