### PR TITLE
Add .preload file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.env.local
 /.env.local.php
 /.env.*.local
+/src/.preload.php
 /public/bundles/
 /var/
 /vendor/


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

The `.preload.php` should be added to `.gitignore`, still sulu does not support preload opcache as classes conflicts in the 2 Kernel setup and it end up in a strange behaviour which could end in data loses. See more here: https://github.com/symfony/symfony/issues/38334

#### Why?

See https://github.com/symfony/recipes/blob/67670e2ebc7c7cbeb8b34f714058cabeb00052bd/symfony/framework-bundle/4.2/manifest.json#L26
