### PR TITLE
Add postcss config to skeleton

### DIFF
--- a/assets/admin/postcss.config.js
+++ b/assets/admin/postcss.config.js
@@ -1,5 +1,8 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+/* eslint-disable import/no-nodejs-modules */
 const path = require('path');
 
+// eslint-disable-next-line no-undef
 module.exports = {
     plugins: {
         'postcss-import': {

--- a/assets/admin/postcss.config.js
+++ b/assets/admin/postcss.config.js
@@ -1,2 +1,14 @@
-/* reuse the postcss configuration included in sulu */
-module.exports = require('../../vendor/sulu/sulu/postcss.config.js');
+const path = require('path');
+
+module.exports = {
+    plugins: {
+        'postcss-import': {
+            path: path.resolve(process.cwd(), 'node_modules'),
+        },
+        'postcss-nested': {},
+        'postcss-simple-vars': {},
+        'postcss-calc': {},
+        'postcss-hexrgba': {},
+        'autoprefixer': {},
+    },
+};

--- a/assets/admin/postcss.config.js
+++ b/assets/admin/postcss.config.js
@@ -1,0 +1,2 @@
+/* reuse the postcss configuration included in sulu */
+module.exports = require('../../vendor/sulu/sulu/postcss.config.js');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | Not yet created
| License | MIT

#### What's in this PR?

Added postcss.config.js file to the skeleton. 

#### Why?

Else the custom scss placed in `assets/admin` doesn't get compiled out of the box.

#### To Do
- [ ] Create PR for sulu/sulu to update also in the build command: https://github.com/sulu/sulu/blob/3f2225e3defcc8cfc218380c2e65d65b1084bf31/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php#L103
