### PR TITLE
Fix stof extension bundle default locale

### DIFF
--- a/config/packages/stof_doctrine_extensions.yaml
+++ b/config/packages/stof_doctrine_extensions.yaml
@@ -1,4 +1,4 @@
 # Read the documentation: https://symfony.com/doc/current/bundles/StofDoctrineExtensionsBundle/index.html
 # See the official DoctrineExtensions documentation for more details: https://github.com/Atlantic18/DoctrineExtensions/tree/master/doc/
 stof_doctrine_extensions:
-    default_locale: en_US
+    default_locale: '%default_locale%'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix stof extension bundle default locale

#### Why?

Looks like this was changed by @danrot over symfony recipe update which should not had happened: https://github.com/sulu/skeleton/commit/d61ee16db74464d091a2ac6d9a270171b6fef219
