### PR TITLE
Fix: Use GitHub Actions instead of Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
     <a href="https://github.com/sulu/skeleton/releases" target="_blank">
         <img src="https://img.shields.io/github/tag/sulu/skeleton.svg" alt="GitHub tag (latest SemVer)">
     </a>
-    <a href="https://travis-ci.org/sulu/skeleton" target="_blank">
-        <img src="https://img.shields.io/travis/sulu/skeleton.svg?label=travis" alt="Travis build">
+    <a href="https://github.com/sulu/skeleton/actions" target="_blank">
+        <img src="https://img.shields.io/github/workflow/status/sulu/skeleton/Test%20application/master.svg?label=test-workflow" alt="Test workflow status">
     </a>
 </p>
 <br/>


### PR DESCRIPTION
This PR

* [x] uses a GitHub Actions badge instead of a Travis CI badge

Follows #79.