### PR TITLE
Remove duplicated asset install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,11 +76,10 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR% --symlink --relative": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "bin/websiteconsole cache:clear": "php-script",
             "bin/adminconsole sulu:media:init": "php-script",
-            "bin/adminconsole massive:search:init": "php-script",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+            "bin/adminconsole massive:search:init": "php-script"
         },
         "post-install-cmd": [
             "@auto-scripts"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove duplicated asset install.

#### Why?

As I personally would prefer todo a symlink. Symfony decided against it and the recipe update will always create the asset install again. As in symfony it seems like there were issues: https://github.com/symfony/recipes/issues/398. As we currently can not workaround that flex would always add `asset:install` the way they want it, I will add it this way to avoid future duplicated assets install.
