### PR TITLE
Specify supported npm versions in package.json and enable engine-strict to check npm version on install

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -20,7 +20,7 @@ jobs:
             matrix:
                 include:
                     - php-version: '7.2'
-                      node-version: '10'
+                      node-version: '12'
                       mysql-version: '5.7'
                       create-project: true
                       create-database: true

--- a/assets/admin/.npmrc
+++ b/assets/admin/.npmrc
@@ -1,0 +1,3 @@
+# the javascript setup in this folder is not compatible with npm 7: https://github.com/sulu/skeleton/issues/88
+# to display a helpful error message if an incompatible version is used, we enable the "engine-strict" setting
+engine-strict=true

--- a/assets/admin/package.json
+++ b/assets/admin/package.json
@@ -58,5 +58,8 @@
         "webpack-clean-obsolete-chunks": "^0.4.0",
         "webpack-cli": "^3.1.1",
         "webpack-manifest-plugin": "^2.0.2"
+    },
+    "engines": {
+        "npm": "<7"
     }
 }


### PR DESCRIPTION
With this changes, the following error message is displayed when running `npm install` using `npm 7`:

```
▶ npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: undefined
npm ERR! notsup Not compatible with your version of node/npm: undefined
npm ERR! notsup Required: {"npm":"<7"}
npm ERR! notsup Actual:   {"npm":"7.7.6","node":"v12.17.0"}
```