### PR TITLE
Add admin path to firewall

### DIFF
--- a/config/packages/security_admin.yaml
+++ b/config/packages/security_admin.yaml
@@ -25,7 +25,7 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         admin:
-            pattern: ^/
+            pattern: ^/admin(\/|$)
             anonymous: true
             lazy: true
             provider: sulu


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add admin path to firewall.

#### Why?

So when we go in future with a single kernel setup the admin and website security need to be merged together. This is a first step so if somebody configure a path for the admin they need to make sure that the `security_admin.yaml` is also updated.

