### PR TITLE
Activate FOSJSRoutingBundle also for website context

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -39,7 +39,7 @@ return [
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Sulu\Bundle\PreviewBundle\SuluPreviewBundle::class => ['all' => true, 'admin' => true],
-    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true, 'admin' => true],
+    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true],
     Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle::class => ['all' => true, 'website' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
     Sulu\Bundle\EventLogBundle\SuluEventLogBundle::class => ['all' => true],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/6000
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Activate FOSJSRoutingBundle also for website context.

#### Why?

Make it easier in the future to migrate to a single kernel setup.
