### PR TITLE
Add main tag to base template

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -42,13 +42,9 @@
         <input type="submit" value="Go"/>
     </form>
 
-    <section id="content">
+    <main id="content">
         {% block content %}{% endblock %}
-    </section>
-
-    <aside>
-        {% block aside %}{% endblock %}
-    </aside>
+    </main>
 
     <footer>
         {% block footer %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add `main` tag instead of section to the base template. and remove unused `aside` block.

#### Why?

Matches seo best practies to have atleast a `nav`, `header`, `main`,  `footer` section.
