### PR TITLE
Remove id from main tag in base template

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -42,7 +42,7 @@
         <input type="submit" value="Go"/>
     </form>
 
-    <main id="content">
+    <main>
         {% block content %}{% endblock %}
     </main>
 


### PR DESCRIPTION
I think this was needed in 1.6 for the preview functionality, but is not needed with 2.0 anymore 🙂 