### PR TITLE
Remove unneeded defaultLocale for seo.html.twig

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,7 +11,6 @@
             "content": content|default([]),
             "urls": urls|default([]),
             "shadowBaseLocale": shadowBaseLocale|default(),
-            "defaultLocale": app.request.locale
         } %}
     {% endblock %}
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | sulu/sulu#6071
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove unneeded defaultLocale for seo.html.twig.

#### Why?

Not longer needed in the seo.html.twig extension.