### PR TITLE
Always transpile nullish coalescing operator because it cannot be processed by webpack 4

### DIFF
--- a/assets/admin/babel.config.json
+++ b/assets/admin/babel.config.json
@@ -2,7 +2,8 @@
     "presets": ["@babel/preset-env", "@babel/preset-react"],
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
-        "@babel/plugin-transform-flow-strip-types"
+        "@babel/plugin-transform-flow-strip-types",
+        "@babel/plugin-proposal-nullish-coalescing-operator"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/assets/admin/package.json
+++ b/assets/admin/package.json
@@ -31,6 +31,7 @@
     "devDependencies": {
         "@babel/core": "^7.5.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",


### PR DESCRIPTION
#### What's in this PR?

This PR adds the `@babel/plugin-proposal-nullish-coalescing-operator` plugin to our babel configuration to transpile the code of the `react-leaflet` package. Without this change, the build errors with the following message when installing the newest version of the `react-leaflet` package:

```
ERROR in /sulu-skeleton/vendor/sulu/sulu/node_modules/react-leaflet/esm/Pane.js 25:37
Module parse failed: Unexpected token (25:37)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   }
| 
>   const parentPaneName = props.pane ?? context.pane;
|   const parentPane = parentPaneName ? context.map.getPane(parentPaneName) : undefined;
|   const element = context.map.createPane(name, parentPane);
 @ /sulu-skeleton/vendor/sulu/sulu/node_modules/react-leaflet/esm/index.js 13:0-30 13:0-30
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/Location.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/index.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/fields/Location.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/index.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/index.js
 @ ./index.js
```

#### Related Issues

- https://github.com/sulu/sulu/pull/6056
- https://github.com/PaulLeCam/react-leaflet/issues/883