### PR TITLE
Add postinstall info to post project install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
-    "license": "proprietary",
+    "name": "sulu/skeleton",
+    "license": "MIT",
     "type": "project",
+    "description": "Project template for starting your new project based on the Sulu content management system",
     "homepage": "https://sulu.io/",
     "keywords": [
         "symfony",
@@ -34,7 +36,7 @@
         "friendsofsymfony/http-cache-bundle": "^2.8",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
-        "sulu/sulu": "~2.3.0",
+        "sulu/sulu": "~2.3.0@dev",
         "symfony/config": "^5.1",
         "symfony/dotenv": "^5.1",
         "symfony/flex": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
-    "name": "sulu/skeleton",
-    "license": "MIT",
+    "license": "proprietary",
     "type": "project",
-    "description": "Project template for starting your new project based on the Sulu content management system",
     "homepage": "https://sulu.io/",
     "keywords": [
         "symfony",
@@ -93,7 +91,8 @@
             "@php -r \"file_put_contents('.env', str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
         ],
         "post-create-project-cmd": [
-            "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\""
+            "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",
+            "@php bin/adminconsole sulu:admin:info --ansi"
         ]
     },
     "config": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add info command to post project.

#### Why?

Where a developer can find informations about sulu.

#### Example Usage

```php
composer create-project sulu/skeleton:dev-feature/post-install-info-command test-project --repository="{\"type\":\"vcs\",\"url\":\"git@github.com:alexander-schranz/skeleton.git\"}" --stability=dev --no-cache
```

