### PR TITLE
Add confliciting node_modules.bak to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ symfony.lock
 # npm
 package-lock.json
 node_modules
+node_modules.bak
 
 # phpunit
 .phpunit


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/6114
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add confliciting node_modules.bak to gitignore.

#### Why?

This could exist after a cancelled sulu:admin:update-build command.
