### PR TITLE
Add conflict to incompatible flex 1.14.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
             "App\\Tests\\": "tests/"
         }
     },
+    "conflict": {
+        "symfony/flex": "1.14.0"
+    },
     "replace": {
         "paragonie/random_compat": "2.*",
         "symfony/polyfill-ctype": "*",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add conflict to incompatible flex 1.14.0 version.

#### Why?

There is currently an issue with flex removing dev dependencies: https://github.com/symfony/flex/issues/784
