### PR TITLE
Enable legacy-peer-deps in .npmrc file to display helpful error message when using npm 7

### DIFF
--- a/assets/admin/.npmrc
+++ b/assets/admin/.npmrc
@@ -8,3 +8,8 @@ unsafe-perm=true
 # the javascript setup in this folder is not compatible with npm 7: https://github.com/sulu/skeleton/issues/88
 # to display a helpful error message if an incompatible version is used, we enable the "engine-strict" setting
 engine-strict=true
+
+# unfortunately, npm 7 tries to resolve the dependency tree before validating the "engines" section of the
+# package.json. to display a helpful message instead of a confusing dependency tree error when using npm 7, we enable
+# the "legacy-peer-deps" setting: https://github.com/sulu/skeleton/issues/133#issuecomment-907271497
+legacy-peer-deps=true


### PR DESCRIPTION
| Q | A
| --- | ---
| Related issues/PRs | https://github.com/sulu/sulu/pull/6200 https://github.com/sulu/skeleton/issues/133

#### What's in this PR?

This PR enables the `legacy-peer-deps` setting in the `assets/admin/.npmrc` file.

#### Why?

Because npm tries to resolve the dependency tree before validating the `engines` section of the `pacakge.json`. Because of this, users see a confusing dependency tree error message instead of the message that sulu is not compatible with npm 7. See https://github.com/sulu/skeleton/issues/133
