### PR TITLE
Add `kernel.reset` tag for cache provider service definitions

### DIFF
--- a/config/packages/prod/sulu_document_manager.yaml
+++ b/config/packages/prod/sulu_document_manager.yaml
@@ -17,12 +17,16 @@ services:
         public: false
         arguments:
             - '@doctrine_phpcr.meta_cache_pool'
+        tags:
+            - { name: 'kernel.reset', method: 'reset' }
 
     doctrine_phpcr.nodes_cache_provider:
         class: Symfony\Component\Cache\DoctrineProvider
         public: false
         arguments:
             - '@doctrine_phpcr.nodes_cache_pool'
+        tags:
+            - { name: 'kernel.reset', method: 'reset' }
 
 framework:
     cache:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Add `kernel.reset` tag for doctrine phpcr nodes & metadata cache provider service definition. Mostly required to run sulu with Roadrunner or Swoole. But also required for messenger consume where services are also resetted between messages.


