### PR TITLE
Add hint that additional bundles also should be in app.js

### DIFF
--- a/assets/admin/app.js
+++ b/assets/admin/app.js
@@ -1,1 +1,1 @@
-// Add project specific javascript code here:
+// Add project specific javascript code and import of additional bundles here:

--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -1,4 +1,4 @@
-// This file should only be changed by the `bin/adminconsole sulu:admin:update-build` command:
+// This file should only be changed by the `bin/console sulu:admin:update-build` command:
 // See https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html
 
 // Sulu Core Bundles

--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -1,4 +1,7 @@
-// Bundles
+// This file should only be changed by the `bin/adminconsole sulu:admin:update-build` command:
+// See https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html
+
+// Sulu Core Bundles
 import {startAdmin} from 'sulu-admin-bundle';
 import 'sulu-audience-targeting-bundle';
 import 'sulu-category-bundle';
@@ -14,7 +17,7 @@ import 'sulu-security-bundle';
 import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';
 
-// Add project specific javascript code to the following file:
+// Add project specific javascript code and import of additional bundles to the following file:
 import './app.js';
 
 // Start admin application


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add hint that additional bundles also should be in app.js.

#### Why?

Because its not clear that custom bundles should also be in the app.js.
