### PR TITLE
Use arm compatible docker mysql image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,13 @@ version: '3'
 services:
 ###> doctrine/doctrine-bundle ###
     database:
-        image: mysql:${MYSQL_VERSION:-8}
+        # arm compatible mysql docker image
+        image: mysql/mysql-server:${MYSQL_VERSION:-8.0} # arm and x86/x64 compatible mysql image
         environment:
             MYSQL_DATABASE: ${MYSQL_DATABASE:-su_myapp}
             # You should definitely change the password in production
             MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-ChangeMe}
+            MYSQL_ROOT_HOST: '%'
         volumes:
             - db-data:/var/lib/mysql
             # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use arm compatible docker mysql image.

#### Why?

That docker compose works on arm and x86x64 machines for a faster start with sulu.
