### PR TITLE
Add PHP 8.1 to skeleton CI

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -62,6 +62,22 @@ jobs:
                           SULU_ADMIN_EMAIL:
                           DATABASE_URL: "mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=5.7"
 
+                    - php-version: '8.1'
+                      node-version: '14'
+                      mysql-version: '8.0'
+                      create-project: true
+                      create-database: true
+                      checkout-directory: 'project'
+                      working-directory: 'create-project-test'
+                      php-extensions: 'ctype, iconv, mysql, gd'
+                      tools: 'composer:v2'
+                      env:
+                          APP_ENV: test
+                          APP_SECRET: a448d1dfcaa563fce56c2fd9981f662b
+                          MAILER_URL: null://localhost
+                          SULU_ADMIN_EMAIL:
+                          DATABASE_URL: "mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=8.0"
+
         services:
             mysql:
                 image: mysql:${{ matrix.mysql-version }}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add PHP 8.1 to skeleton CI

#### Why?

To test also the skeleton with PHP 8.1
