### PR TITLE
Fix doctrine cache for stage environment

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -42,4 +42,4 @@ when@prod: &prod
                 doctrine.system_cache_pool:
                     adapter: cache.system
 
-when@stage: &prod
+when@stage: *prod


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix yaml pointer for doctrine caches.

#### Why?

Currently the pointer is not correct and so stage does not have doctrine cached activated.