### PR TITLE
Fix docker file indent

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,7 +8,7 @@ services:
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mailer ###
-  mailer:
-    image: schickling/mailcatcher
-    ports: [1025, 1080]
+    mailer:
+        image: schickling/mailcatcher
+        ports: [1025, 1080]
 ###< symfony/mailer ###


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix docker file formatting.

#### Why?

False formatted docker file ends in:

> yaml: line 10: did not find expected key

