### PR TITLE
Fix indention from docker files

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
 ###> doctrine/doctrine-bundle ###
-    database:
-        ports:
-            - "3306:3306"
+  database:
+    ports:
+      - "3306:3306"
 ###< doctrine/doctrine-bundle ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,21 @@ version: '3'
 
 services:
 ###> doctrine/doctrine-bundle ###
-    database:
-        # arm compatible mysql docker image
-        image: mysql/mysql-server:${MYSQL_VERSION:-8.0} # arm and x86/x64 compatible mysql image
-        environment:
-            MYSQL_DATABASE: ${MYSQL_DATABASE:-su_myapp}
-            # You should definitely change the password in production
-            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-ChangeMe}
-            MYSQL_ROOT_HOST: '%'
-        volumes:
-            - db-data:/var/lib/mysql
-            # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
-            # - ./docker/db/data:/var/lib/mysql:rw
+  database:
+    # arm compatible mysql docker image
+    image: mysql/mysql-server:${MYSQL_VERSION:-8.0} # arm and x86/x64 compatible mysql image
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-su_myapp}
+      # You should definitely change the password in production
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-ChangeMe}
+      MYSQL_ROOT_HOST: '%'
+    volumes:
+      - db-data:/var/lib/mysql
+      # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
+      # - ./docker/db/data:/var/lib/mysql:rw
 ###< doctrine/doctrine-bundle ###
 
 volumes:
 ###> doctrine/doctrine-bundle ###
-    db-data:
+  db-data:
 ###< doctrine/doctrine-bundle ###


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix indention of docker files.

#### Why?

Symfony provides 2 space indention for the docker files and so it is required sulu uses the same. Symfony goes this way because it is recommended 2 space from docker itself.
