### PR TITLE
Remove PHP 7.4 CI and lower

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -19,35 +19,8 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.2'
-                      node-version: '12'
-                      mysql-version: '5.7'
-                      create-project: true
-                      create-database: true
-                      checkout-directory: 'project'
-                      working-directory: 'create-project-test'
-                      php-extensions: 'ctype, iconv, mysql, gd'
-                      tools: 'composer:v2'
-                      env: {}
-
-                    - php-version: '7.4'
-                      node-version: '12'
-                      mysql-version: '8.0'
-                      create-project: false
-                      create-database: false
-                      checkout-directory: 'project'
-                      working-directory: 'project'
-                      php-extensions: 'ctype, iconv, mysql, imagick'
-                      tools: 'composer:v2'
-                      env:
-                          APP_ENV: test
-                          APP_SECRET: a448d1dfcaa563fce56c2fd9981f662b
-                          MAILER_URL: null://localhost
-                          SULU_ADMIN_EMAIL:
-                          DATABASE_URL: "mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=8.0"
-
                     - php-version: '8.0'
-                      node-version: '14'
+                      node-version: '12'
                       mysql-version: '5.7'
                       create-project: false
                       create-database: false
@@ -204,7 +177,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.4'
+                    - php-version: '8.1'
                       node-version: '14'
                       mysql-version: '8.0'
                       php-extensions: 'ctype, iconv, intl, mysql, pdo_mysql, php_fileinfo, imagick'

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "chat": "https://sulu.io/services-and-support#chat"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0 || ^8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "dantleech/phpcr-migrations-bundle": "^1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/6553
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove PHP 7.4 CI and lower.

#### Why?

Sulu drops PHP 7.4 support and lower for future Symfony 6.