### PR TITLE
Upgrade PHPCR cache config to doctrine/cache package

### DIFF
--- a/config/packages/sulu_document_manager.yaml
+++ b/config/packages/sulu_document_manager.yaml
@@ -31,7 +31,8 @@ when@prod: &prod
 
     services:
         doctrine_phpcr.meta_cache_provider:
-            class: Symfony\Component\Cache\DoctrineProvider
+            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
             public: false
             arguments:
                 - '@doctrine_phpcr.meta_cache_pool'
@@ -39,7 +40,8 @@ when@prod: &prod
                 - { name: 'kernel.reset', method: 'reset' }
 
         doctrine_phpcr.nodes_cache_provider:
-            class: Symfony\Component\Cache\DoctrineProvider
+            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
             public: false
             arguments:
                 - '@doctrine_phpcr.nodes_cache_pool'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Upgrade PHPCR cache config to doctrine/cache package.

#### Why?

Symfony 6 does not longer provide the `Symfony\Component\Cache\DoctrineProvider` and so the new `Doctrine\Common\Cache\Psr6\DoctrineProvider` need to be used. Which need to be created over a factory method.