### PR TITLE
Upgrade DocumentManager DoctrineProvider bridge

### DIFF
--- a/config/packages/sulu_document_manager.yaml
+++ b/config/packages/sulu_document_manager.yaml
@@ -31,7 +31,8 @@ when@prod: &prod
 
     services:
         doctrine_phpcr.meta_cache_provider:
-            class: Symfony\Component\Cache\DoctrineProvider
+            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
             public: false
             arguments:
                 - '@doctrine_phpcr.meta_cache_pool'
@@ -39,7 +40,8 @@ when@prod: &prod
                 - { name: 'kernel.reset', method: 'reset' }
 
         doctrine_phpcr.nodes_cache_provider:
-            class: Symfony\Component\Cache\DoctrineProvider
+            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
             public: false
             arguments:
                 - '@doctrine_phpcr.nodes_cache_pool'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs |  https://github.com/sulu/sulu/pull/6601, https://github.com/doctrine/cache/pull/398, https://github.com/sulu/sulu/issues/6556
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Upgrade DocumentManager DoctrineProvider bridge.

#### Why?

For Future Symfony 6 support.