### PR TITLE
Add phpstan, rector, php-cs-fixer and linting scripts

### DIFF
--- a/.github/disable-windows-scripts.sh
+++ b/.github/disable-windows-scripts.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-php -r 'file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json")));'
-php -r 'file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
-
-cat composer.json

--- a/.github/disable-windows-scripts.sh
+++ b/.github/disable-windows-scripts.sh
@@ -2,3 +2,5 @@
 
 php -r 'file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json")));'
 php -r 'file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
+
+cat composer.json

--- a/.github/disable-windows-scripts.sh
+++ b/.github/disable-windows-scripts.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+php -r 'file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json")));'
+php -r 'file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -199,6 +199,7 @@ jobs:
                   DISABLE_SCRIPT: '<?php file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json"))); file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
               run: |
                   echo $DISABLE_SCRIPT > disable.php
+                  cat disable.php
                   php disable.php
                   cat composer.json
                   rm disable.php

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -195,10 +195,13 @@ jobs:
             # Github clones with false line endings on Windows make php-cs-fix fail
             # Rector seems to fail on Windows with child processes
             - name: Disable php-cs and rector
+              env:
+                  DISABLE_SCRIPT: '<?php file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json"))); file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
               run: |
-                  php -r 'file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json")));'
-                  php -r 'file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
+                  echo $DISABLE_SCRIPT > disable.php
+                  php disable.php
                   cat composer.json
+                  rm disable.php
 
             - name: Install and configure MySQL
               uses: shogo82148/actions-setup-mysql@v1.0.1

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -222,7 +222,10 @@ jobs:
                   bin/websiteconsole cache:clear --env prod
 
             - name: Lint Code
-              run: composer lint
+              # lint code but without code style as windows clones with false line endings
+              run: |
+                  php -r 'file_put_contents("composer.json", str_replace("\"php-cs-fix", "\"deactivate-php-cs-fix", file_get_contents("composer.json")));'
+                  composer lint
 
             - name: Bootstrap tests
               run: composer bootstrap-test-environment

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -224,7 +224,7 @@ jobs:
             - name: Lint Code
               # lint code but without code style as windows clones with false line endings
               run: |
-                  php -r 'file_put_contents("composer.json", str_replace("\"php-cs-fix", "\"deactivate-php-cs-fix", file_get_contents("composer.json")));'
+                  php -r 'file_put_contents(\'composer.json\', str_replace(\'"php-cs-fix\', \'\"deactivate-php-cs-fix\', file_get_contents(\'composer.json\')));'
                   composer lint
 
             - name: Bootstrap tests

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -117,33 +117,20 @@ jobs:
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
 
-            - name: Lint container
-              run: |
-                  bin/adminconsole lint:container --env dev
-                  bin/websiteconsole lint:container --env dev
-                  bin/adminconsole lint:container --env test
-                  bin/websiteconsole lint:container --env test
-                  bin/adminconsole lint:container --env stage
-                  bin/websiteconsole lint:container --env stage
-                  bin/adminconsole lint:container --env prod
-                  bin/websiteconsole lint:container --env prod
+            - name: Lint Code
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
+              run: composer lint
 
-            - name: Lint code
-              run: |
-                  ${{ matrix.create-project }} || composer validate --strict
-                  bin/adminconsole doctrine:ensure-production-settings --env prod
-                  bin/adminconsole doctrine:schema:validate
-                  bin/adminconsole lint:twig templates
-                  bin/adminconsole lint:yaml config
+            - name: Bootstrap tests
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
+              run: composer bootstrap-test-environment
 
             - name: Execute test cases
-              run: bin/phpunit
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
+              run: composer test
 
             - name: Test download-language script
               run: bin/adminconsole sulu:admin:download-language nl
@@ -234,27 +221,14 @@ jobs:
                   bin/adminconsole cache:clear --env prod
                   bin/websiteconsole cache:clear --env prod
 
-            - name: Lint container
-              run: |
-                  bin/adminconsole lint:container --env dev
-                  bin/websiteconsole lint:container --env dev
-                  bin/adminconsole lint:container --env test
-                  bin/websiteconsole lint:container --env test
-                  bin/adminconsole lint:container --env stage
-                  bin/websiteconsole lint:container --env stage
-                  bin/adminconsole lint:container --env prod
-                  bin/websiteconsole lint:container --env prod
+            - name: Lint Code
+              run: composer lint
 
-            - name: Lint code
-              run: |
-                  composer validate --strict
-                  bin/adminconsole doctrine:ensure-production-settings --env prod
-                  bin/adminconsole doctrine:schema:validate
-                  bin/adminconsole lint:twig templates
-                  bin/adminconsole lint:yaml config
+            - name: Bootstrap tests
+              run: composer bootstrap-test-environment
 
             - name: Execute test cases
-              run: bin/phpunit
+              run: composer test
 
             - name: Test download-language script
               run: bin/adminconsole sulu:admin:download-language nl

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -195,7 +195,10 @@ jobs:
             # Github clones with false line endings on Windows make php-cs-fix fail
             # Rector seems to fail on Windows with child processes
             - name: Disable php-cs and rector
-              run: ./.github/disable-windows-scripts.sh
+              run: |
+                  php -r 'file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json")));'
+                  php -r 'file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
+                  cat composer.json
 
             - name: Install and configure MySQL
               uses: shogo82148/actions-setup-mysql@v1.0.1

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -195,10 +195,8 @@ jobs:
             # Github clones with false line endings on Windows make php-cs-fix fail
             # Rector seems to fail on Windows with child processes
             - name: Disable php-cs and rector
-              env:
-                  DISABLE_SCRIPT: '<?php file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json"))); file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));'
               run: |
-                  echo $DISABLE_SCRIPT > disable.php
+                  echo '<?php file_put_contents("composer.json", str_replace("\"lint-php-cs", "\"deactivate-lint-php-cs-fix", file_get_contents("composer.json"))); file_put_contents("composer.json", str_replace("\"lint-rector", "\"deactivate-lint-rector", file_get_contents("composer.json")));' > disable.php
                   cat disable.php
                   php disable.php
                   cat composer.json

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -192,6 +192,11 @@ jobs:
                   tools: ${{ matrix.tools }}
                   ini-values: 'memory_limit=-1'
 
+            # Github clones with false line endings on Windows make php-cs-fix fail
+            # Rector seems to fail on Windows with child processes
+            - name: Disable php-cs and rector
+              run: ./.github/disable-windows-scripts.sh
+
             - name: Install and configure MySQL
               uses: shogo82148/actions-setup-mysql@v1.0.1
               with:
@@ -200,11 +205,6 @@ jobs:
                   my-cnf: |
                       [mysqld]
                       default-authentication-plugin=mysql_native_password
-
-            # Github clones with false line endings on Windows make php-cs-fix fail
-            # Rector seems to fail on Windows with child processes
-            - name: Disable php-cs and rector
-              run: ./.github/disable-windows-scripts.sh
 
             - name: Install composer dependencies
               uses: ramsey/composer-install@v1

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -221,10 +221,12 @@ jobs:
                   bin/adminconsole cache:clear --env prod
                   bin/websiteconsole cache:clear --env prod
 
+            - name: Fix Code Style
+              # fix code as windows clones with false line endings which makes composer lint failing
+              run: composer php-cs-fix
+
             - name: Lint Code
-              # lint code but without code style as windows clones with false line endings
               run: |
-                  php -r 'file_put_contents(\'composer.json\', str_replace(\'"php-cs-fix\', \'\"deactivate-php-cs-fix\', file_get_contents(\'composer.json\')));'
                   composer lint
 
             - name: Bootstrap tests

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -201,6 +201,11 @@ jobs:
                       [mysqld]
                       default-authentication-plugin=mysql_native_password
 
+            # Github clones with false line endings on Windows make php-cs-fix fail
+            # Rector seems to fail on Windows with child processes
+            - name: Disable php-cs and rector
+              run: ./.github/disable-windows-scripts.sh
+
             - name: Install composer dependencies
               uses: ramsey/composer-install@v1
               with:
@@ -220,10 +225,6 @@ jobs:
                   bin/websiteconsole cache:clear --env stage
                   bin/adminconsole cache:clear --env prod
                   bin/websiteconsole cache:clear --env prod
-
-            - name: Fix Code Style
-              # fix code as windows clones with false line endings which makes composer lint failing
-              run: composer php-cs-fix
 
             - name: Lint Code
               run: |

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@
 .phpunit.result.cache
 ###< phpunit/phpunit ###
 
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###
+
 # web
 /public/bundles
 /public/uploads

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude(['var', 'lib', 'node_modules'])
+    ->notName('bundles.php');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'ordered_imports' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'array_syntax' => ['syntax' => 'short'],
+        'phpdoc_align' => ['align' => 'left'],
+        'class_definition' => [
+            'multi_line_extends_each_single_line' => true,
+        ] ,
+        'linebreak_after_opening_tag' => true,
+        'declare_strict_types' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'native_constant_invocation' => true,
+        'native_function_casing' => true,
+        'native_function_invocation' => ['include' => ['@internal']],
+        'no_php4_constructor' => true,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'php_unit_strict' => true,
+        'phpdoc_order' => true,
+        'semicolon_after_instruction' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'array_indentation' => true,
+        'multiline_whitespace_before_semicolons' => true,
+        'single_line_throw' => false,
+        'visibility_required' => ['elements' => ['property', 'method', 'const']],
+        'phpdoc_to_comment' => [
+            'ignored_tags' => ['todo', 'var'],
+        ],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
+    ])
+    ->setFinder($finder);

--- a/bin/console.php
+++ b/bin/console.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -12,11 +14,11 @@
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
-if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+if (!\is_file(\dirname(__DIR__) . '/vendor/autoload_runtime.php')) {
     throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
 }
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once \dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 if (!isset($suluContext)) {
     $suluContext = Kernel::CONTEXT_ADMIN;

--- a/composer.json
+++ b/composer.json
@@ -144,12 +144,12 @@
         "rector": [
             "@php vendor/bin/rector process"
         ],
-        "lint-rector": [
+        "deactivate-lint-rector": [
             "@php bin/websiteconsole cache:warmup --env=dev",
             "@php vendor/bin/rector process --dry-run"
         ],
         "php-cs-fix": "@php vendor/bin/php-cs-fixer fix",
-        "lint-php-cs": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
+        "deactivate-lint-php-cs-fix": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "lint-composer": "@composer validate --no-check-publish --strict",
         "lint-twig": "@php bin/console lint:twig templates/",
         "lint-yaml": "@php bin/console lint:yaml config/ --parse-tags",

--- a/composer.json
+++ b/composer.json
@@ -49,15 +49,28 @@
         "symfony/twig-bundle": "^6.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.9",
+        "jangregor/phpstan-prophecy": "^1.0",
         "phpcr/phpcr-shell": "^1.4",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-doctrine": "^1.2",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.3",
+        "phpstan/phpstan-symfony": "^1.1",
+        "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5",
+        "rector/rector": "^0.13.8",
+        "sulu/sulu-rector": "^0.1.1",
         "symfony/browser-kit": "^6.0",
         "symfony/css-selector": "^6.0",
         "symfony/debug-bundle": "^6.0",
         "symfony/error-handler": "^6.0",
         "symfony/phpunit-bridge": "^6.0",
         "symfony/thanks": "^1.2",
-        "symfony/web-profiler-bundle": "^6.0"
+        "symfony/web-profiler-bundle": "^6.0",
+        "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -102,6 +115,54 @@
         "post-create-project-cmd": [
             "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",
             "@php bin/adminconsole sulu:admin:info --ansi"
+        ],
+        "bootstrap-test-environment": [
+            "@php bin/adminconsole doctrine:database:drop --if-exists --force --env test",
+            "@php bin/adminconsole doctrine:database:create --env test",
+            "@php bin/adminconsole doctrine:schema:create --env test"
+        ],
+        "test": "@php bin/phpunit",
+        "test-with-coverage": "@test --coverage-php var/reports/coverage.php --coverage-cobertura=var/reports/cobertura-coverage.xml --coverage-html var/reports/html --log-junit var/reports/junit.xml",
+        "lint": [
+            "@phpstan",
+            "@lint-php-cs",
+            "@lint-rector",
+            "@lint-twig",
+            "@lint-yaml",
+            "@lint-container",
+            "@lint-composer",
+            "@lint-doctrine"
+        ],
+        "fix": [
+            "@rector",
+            "@php-cs-fix"
+        ],
+        "phpstan": [
+            "@php bin/websiteconsole cache:warmup --env=dev",
+            "@php vendor/bin/phpstan analyze"
+        ],
+        "rector": [
+            "@php vendor/bin/rector process"
+        ],
+        "lint-rector": [
+            "@php bin/websiteconsole cache:warmup --env=dev",
+            "@php vendor/bin/rector process --dry-run"
+        ],
+        "php-cs-fix": "@php vendor/bin/php-cs-fixer fix",
+        "lint-php-cs": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
+        "lint-composer": "@composer validate --no-check-publish --strict",
+        "lint-twig": "@php bin/console lint:twig templates/",
+        "lint-yaml": "@php bin/console lint:yaml config/ --parse-tags",
+        "lint-container": [
+            "@php bin/console lint:container --env dev",
+            "@php bin/console lint:container --env test",
+            "@php bin/console lint:container --env stage",
+            "@php bin/console lint:container --env prod"
+        ],
+        "lint-doctrine": [
+            "@php bin/console doctrine:schema:validate --skip-sync",
+            "@php bin/console doctrine:ensure-production-settings --env stage",
+            "@php bin/console doctrine:ensure-production-settings --env prod"
         ]
     },
     "config": {
@@ -109,7 +170,8 @@
             "composer/package-versions-deprecated": true,
             "symfony/flex": true,
             "symfony/runtime": true,
-            "symfony/thanks": true
+            "symfony/thanks": true,
+            "phpstan/extension-installer": true
         },
         "optimize-autoloader": true,
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -144,12 +144,12 @@
         "rector": [
             "@php vendor/bin/rector process"
         ],
-        "deactivate-lint-rector": [
+        "lint-rector": [
             "@php bin/websiteconsole cache:warmup --env=dev",
             "@php vendor/bin/rector process --dry-run"
         ],
         "php-cs-fix": "@php vendor/bin/php-cs-fixer fix",
-        "deactivate-lint-php-cs-fix": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
+        "lint-php-cs-fix": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "lint-composer": "@composer validate --no-check-publish --strict",
         "lint-twig": "@php bin/console lint:twig templates/",
         "lint-yaml": "@php bin/console lint:yaml config/ --parse-tags",

--- a/config/preload.php
+++ b/config/preload.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // if (file_exists(dirname(__DIR__).'/var/cache/admin/prod/App_KernelProdContainer.preload.php')) {
 //    require dirname(__DIR__).'/var/cache/admin/prod/App_KernelProdContainer.preload.php';
 // }

--- a/config/router.php
+++ b/config/router.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -10,24 +12,24 @@
  */
 
 // Workaround https://bugs.php.net/64566
-$autoPrependFile = ini_get('auto_prepend_file');
-if ($autoPrependFile && !in_array(realpath($autoPrependFile), get_included_files(), true)) {
-    require ini_get('auto_prepend_file');
+$autoPrependFile = \ini_get('auto_prepend_file');
+if (false !== $autoPrependFile && !\in_array(\realpath($autoPrependFile), \get_included_files(), true)) {
+    require \ini_get('auto_prepend_file');
 }
 
-if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
+if (\is_file($_SERVER['DOCUMENT_ROOT'] . \DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
     return false;
 }
 
 $script = isset($_ENV['APP_FRONT_CONTROLLER']) ? $_ENV['APP_FRONT_CONTROLLER'] : 'index.php';
 
-$_SERVER = array_merge($_SERVER, $_ENV);
-$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $script;
+$_SERVER = \array_merge($_SERVER, $_ENV);
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . \DIRECTORY_SEPARATOR . $script;
 
 // Since we are rewriting to app_dev.php, adjust SCRIPT_NAME and PHP_SELF accordingly
-$_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR . $script;
-$_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR . $script;
+$_SERVER['SCRIPT_NAME'] = \DIRECTORY_SEPARATOR . $script;
+$_SERVER['PHP_SELF'] = \DIRECTORY_SEPARATOR . $script;
 
 require $_SERVER['SCRIPT_FILENAME'];
 
-error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);
+\error_log(\sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], \http_response_code(), $_SERVER['REQUEST_URI']), 4);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+    paths:
+        - src
+        - tests
+        - config
+    level: max
+    doctrine:
+        objectManagerLoader: tests/phpstan/object-manager.php
+    symfony:
+        container_xml_path: %currentWorkingDirectory%/var/cache/website/dev/App_KernelDevDebugContainer.xml
+        console_application_loader: tests/phpstan/console-application.php

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -22,7 +24,7 @@ if (SULU_MAINTENANCE) {
     $maintenanceFilePath = __DIR__ . '/maintenance.php';
     // show maintenance mode and exit if no allowed IP is met
     if (require $maintenanceFilePath) {
-        exit();
+        exit;
     }
 }
 

--- a/public/maintenance.php
+++ b/public/maintenance.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 // default locale for maintenance translations
-define('DEFAULT_LOCALE', 'en');
+\define('DEFAULT_LOCALE', 'en');
 
 // allow acces for following ips
 $allowedIPs = [
-  '127.0.0.1',
+    '127.0.0.1',
 ];
 
 // translations for maintenance
@@ -22,18 +22,18 @@ $translations = [
 ];
 
 // check if ip is within allowed range
-if (in_array($_SERVER['REMOTE_ADDR'], $allowedIPs)) {
+if (\in_array($_SERVER['REMOTE_ADDR'], $allowedIPs, true)) {
     return false;
 }
 
 // get language
-$lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+$lang = \substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
 
 // chose locale
-$locale = array_key_exists($lang, $translations) ? $lang : DEFAULT_LOCALE;
+$locale = \array_key_exists($lang, $translations) ? $lang : DEFAULT_LOCALE;
 
-header('Content-Type: text/html; charset=utf-8');
-http_response_code(503);
+\header('Content-Type: text/html; charset=utf-8');
+\http_response_code(503);
 
 ?><!doctype html>
 <html lang="<?php echo $locale; ?>">

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+use Rector\Symfony\Set\SymfonySetList;
+use Sulu\Rector\Set\SuluLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([__DIR__ . '/src', __DIR__ . '/tests']);
+
+    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
+
+    // basic rules
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses();
+
+    $rectorConfig->sets([
+        SetList::CODE_QUALITY,
+        LevelSetList::UP_TO_PHP_81,
+    ]);
+
+    // symfony rules
+    $rectorConfig->symfonyContainerPhp(__DIR__ . '/var/cache/website/dev/App_KernelDevDebugContainer.xml');
+
+    $rectorConfig->sets([
+        SymfonySetList::SYMFONY_CODE_QUALITY,
+        SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
+        SymfonyLevelSetList::UP_TO_SYMFONY_60,
+    ]);
+
+    // doctrine rules
+    $rectorConfig->sets([
+        DoctrineSetList::DOCTRINE_CODE_QUALITY,
+    ]);
+
+    // phpunit rules
+    $rectorConfig->sets([
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_91,
+    ]);
+
+    // sulu rules
+    $rectorConfig->sets([
+        SuluLevelSetList::UP_TO_SULU_25,
+    ]);
+};

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -7,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 
 class AppFixtures extends Fixture
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         // $product = new Product();
         // $manager->persist($product);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 /*
@@ -20,30 +22,27 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class Kernel extends SuluKernel implements HttpCacheProvider
 {
-    /**
-     * @var HttpKernelInterface|null
-     */
-    private $httpCache;
+    private ?HttpKernelInterface $httpCache = null;
 
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->setParameter('container.dumper.inline_class_loader', true);
 
         parent::configureContainer($container, $loader);
     }
 
-    public function getHttpCache()
+    public function getHttpCache(): HttpKernelInterface
     {
-        if (!$this->httpCache) {
+        if (null === $this->httpCache) {
             $this->httpCache = new SuluHttpCache($this);
             // Activate the following for user based caching see also:
             // https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
             //
-            //$this->httpCache->addSubscriber(
+            // $this->httpCache->addSubscriber(
             //    new \FOS\HttpCache\SymfonyCache\UserContextListener([
             //        'session_name_prefix' => 'SULUSESSID',
             //    ])
-            //);
+            // );
         }
 
         return $this->httpCache;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/tests/phpstan/console-application.php
+++ b/tests/phpstan/console-application.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+require \dirname(__DIR__) . '/bootstrap.php';
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel->boot();
+
+return new Application($kernel);

--- a/tests/phpstan/object-manager.php
+++ b/tests/phpstan/object-manager.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Kernel;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+require \dirname(__DIR__) . '/bootstrap.php';
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel->boot();
+
+/** @var ContainerInterface $container */
+$container = $kernel->getContainer();
+
+/** @var EntityManager $objectManager */
+$objectManager = $container->get('doctrine')->getManager();
+
+// remove ResolveTargetEntityListener from returned EntityManager to not resolve SuluPersistenceBundle classes
+// this is a workaround for the following phpstan issue: https://github.com/phpstan/phpstan-doctrine/issues/98
+$resolveTargetEntityListener = \current(\array_filter(
+    $objectManager->getEventManager()->getListeners('loadClassMetadata'),
+    static fn ($listener) => $listener instanceof ResolveTargetEntityListener,
+));
+
+if (false !== $resolveTargetEntityListener) {
+    $objectManager->getEventManager()->removeEventListener([Events::loadClassMetadata], $resolveTargetEntityListener);
+}
+
+return $objectManager;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add phpstan, rector, php-cs-fixer and linting scripts.

#### Why?

We want to provide sulu rector with the skeleton which requires a good configured phpstan configuration. Which we should already ship with the skeleton. In this case the other tooling and linting task which we already use are added the the `composer.json` and should improve the quality of all other sulu projects as we know provide `composer lint` script which will do validation of a lot of files for every sulu project.