### PR TITLE
Fix problems with new postcss-hexrgba version

### DIFF
--- a/assets/admin/package.json
+++ b/assets/admin/package.json
@@ -49,7 +49,7 @@
         "optimize-css-assets-webpack-plugin": "^5.0.3",
         "postcss": "7.0.35",
         "postcss-calc": "^7.0.5",
-        "postcss-hexrgba": "^2.0.0",
+        "postcss-hexrgba": "2.0.*",
         "postcss-import": "^12.0.1",
         "postcss-loader": "^3.0.0",
         "postcss-nested": "^4.2.3",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix problems with new postcss-hexrgba version.

#### Why?

postcss-hexrgba 2.1.0 is not compatible with used postcss 7 so we need stay on `2.0.*`.