### PR TITLE
Add default media image quality and markup data provider configuration

### DIFF
--- a/config/packages/sulu_markup.yaml
+++ b/config/packages/sulu_markup.yaml
@@ -1,0 +1,3 @@
+sulu_markup:
+    link_tag:
+        provider_attribute: 'data-provider'

--- a/config/packages/sulu_markup.yaml
+++ b/config/packages/sulu_markup.yaml
@@ -1,3 +1,4 @@
+# see also: https://docs.sulu.io/en/2.4/bundles/markup/index.html
 sulu_markup:
     link_tag:
         provider_attribute: 'data-provider'

--- a/config/packages/sulu_media.yaml
+++ b/config/packages/sulu_media.yaml
@@ -1,0 +1,7 @@
+sulu_media:
+    format_manager:
+        default_imagine_options:
+            # a value between 95 and 75 is recommended
+            # see also: https://docs.sulu.io/en/2.5/book/image-formats.html
+            jpeg_quality: 90
+            webp_quality: 90


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add default media image quality and markup data provider configuration.

#### Why?

We want to provide better default for sulu_media bundle and activate the data provider by default for sulu 2.5 projects.