### PR TITLE
Disable phpstan strict rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-doctrine": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-strict-rules": "^1.3",
         "phpstan/phpstan-symfony": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Disable phpstan strict rules.

#### Why?

When added I thought we are already using that. But saw then that we did not have it in the current projects.
And there are some rules which I see more as a problem then a solution like e.g.: no `?:` and only boolean check in if we make e.g.: `$query = $request->query->get('test');` to something like `if ($query === null || $query === '') {` instead of `if (!$query) {` which I see currently as problematic and that more bug will created by using here then `if ($query === null)` and forget `$query === ''` then it will actually be removed. Even something like `$test ?: 'default'` can not be done as it also hurts that rule as you are only allowed to `??` which would not include `''` string. As it is already hard for me in some cases I'm currently for removing strict rules.