### PR TITLE
Add conflict to rector 0.13.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,9 @@
         "symfony/web-profiler-bundle": "^6.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
+    "conflict": {
+        "rector/rector": "0.13.9"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "src/"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add conflict to rector 0.13.9 because of https://github.com/rectorphp/rector/issues/7313 which already fixed but release is currently not sure when published.

#### Why?

Fix symfony rector upgrades.
