### PR TITLE
Rename lint-php-cs-fix script to lint-php-cs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,7 @@
             "@php vendor/bin/rector process --dry-run"
         ],
         "php-cs-fix": "@php vendor/bin/php-cs-fixer fix",
-        "lint-php-cs-fix": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
+        "lint-php-cs": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "lint-composer": "@composer validate --no-check-publish --strict",
         "lint-twig": "@php bin/console lint:twig templates/",
         "lint-yaml": "@php bin/console lint:yaml config/ --parse-tags",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Rename lint-php-cs-fix script to lint-php-cs

#### Why?

The script is referenced using`lint-php-cs` name [here](https://github.com/sulu/skeleton/blob/2.5/composer.json#L133)