### PR TITLE
Replace custom php-cs-fixer excludes with ignoreVCSIgnored which uses .gitignore file

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
-    ->exclude(['var', 'lib', 'node_modules'])
+    ->ignoreVCSIgnored(true)
     ->notName('bundles.php');
 
 return (new PhpCsFixer\Config())


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Ignore all php files from .gitignore for php-cs-fixer.

#### Why?

Improve performance for when node_modules exist in assets/website and other gitignore added files which don't need to be analyzed by the php-cs-fixer.
