### PR TITLE
use roles vs role in security.yaml access_control

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -20,7 +20,7 @@ security:
         - { path: ^/admin/reset, roles: PUBLIC_ACCESS }
         - { path: ^/admin/security/reset, roles: PUBLIC_ACCESS }
         - { path: ^/admin/login$, roles: PUBLIC_ACCESS }
-        - { path: ^/admin/2fa, role: PUBLIC_ACCESS }
+        - { path: ^/admin/2fa, roles: PUBLIC_ACCESS }
         - { path: ^/admin/_wdt, roles: PUBLIC_ACCESS }
         - { path: ^/admin/_profiler, roles: PUBLIC_ACCESS }
         - { path: ^/admin/translations, roles: PUBLIC_ACCESS }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | not sure
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

For consistency and to follow the Symfony Docs (https://symfony.com/doc/current/security/access_control.html#2-access-enforcement) `roles` should be used. From what I saw it seems to work with `role` too - probably because of a call to `fixXmlConfig` in the Symfony Security Bundle.
