### PR TITLE
Use symfony style for comment out yaml examples

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -52,43 +52,41 @@ security:
                 success_handler: sulu_security.two_factor_authentication_success_handler
                 failure_handler: sulu_security.two_factor_authentication_failure_handler
 
-#        website:
-#            pattern: ^/
-#            lazy: true
-#            provider: sulu
-#            # The login and logout routes need to be created.
-#            # For an advanced user management with registration and opt-in emails have a look at the:
-#            # https://github.com/sulu/SuluCommunityBundle
-#            # Also have a look at the user context based caching when you output user role specific data
-#            # https://docs.sulu.io/en/2.2/cookbook/user-context-caching.html
-#            form_login:
-#                login_path: login
-#                check_path: login
-#            logout:
-#                path: logout
-#                target: /
-#            remember_me:
-#                secret:   "%kernel.secret%"
-#                lifetime: 604800 # 1 week in seconds
-#                path:     /
-#
-#            # activate different ways to authenticate
-#            # https://symfony.com/doc/current/security.html#the-firewall
-#
-#            # https://symfony.com/doc/current/security/impersonating_user.html
-#            # switch_user: true
+       #website:
+       #    pattern: ^/
+       #    lazy: true
+       #    provider: sulu
+       #    # The login and logout routes need to be created.
+       #    # For an advanced user management with registration and opt-in emails have a look at the:
+       #    # https://github.com/sulu/SuluCommunityBundle
+       #    # Also have a look at the user context based caching when you output user role specific data
+       #    # https://docs.sulu.io/en/2.2/cookbook/user-context-caching.html
+       #    form_login:
+       #        login_path: login
+       #        check_path: login
+       #    logout:
+       #        path: logout
+       #        target: /
+       #    remember_me:
+       #        secret:   "%kernel.secret%"
+       #        lifetime: 604800 # 1 week in seconds
+       #        path:     /
+       #
+       #    # activate different ways to authenticate
+       #    # https://symfony.com/doc/current/security.html#the-firewall
+       #
+       #    # https://symfony.com/doc/current/security/impersonating_user.html
+       #    # switch_user: true
 
 sulu_security:
     checker:
         enabled: true
     password_policy:
         enabled: true
-
-# Sulu uses the simple password_policy pattern ".{8,}" by default
-# You can change it to a more complex pattern with the following lines:
-#
-#        pattern: '(?=^.{8,}$)(?=.*\d)(?=.*[^a-zA-Z0-9]+)(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$'
-#        info_translation_key: app.password_information
+        # Sulu uses the simple password_policy pattern ".{8,}" by default
+        # You can change it to a more complex pattern with the following lines:
+        #pattern: '(?=^.{8,}$)(?=.*\d)(?=.*[^a-zA-Z0-9]+)(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$'
+        #info_translation_key: app.password_information
 
 when@test:
     security:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use symfony style for comment out yaml examples.

#### Why?

Comment are indented in symfony recipes and so allowed to diff between outcommented code and comments. Which will in future maybe be detected to convert outcommented code from yaml to php config without losing example code.
