### PR TITLE
Fix admin build with webpack 4

### DIFF
--- a/assets/admin/babel.config.json
+++ b/assets/admin/babel.config.json
@@ -8,7 +8,8 @@
         "@babel/plugin-transform-flow-strip-types",
         "@babel/plugin-proposal-nullish-coalescing-operator",
         "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining"
+        "@babel/plugin-proposal-optional-chaining",
+        "@babel/plugin-proposal-export-namespace-from"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/assets/admin/package.json
+++ b/assets/admin/package.json
@@ -33,6 +33,7 @@
         "@babel/core": "^7.5.5",
         "@babel/plugin-proposal-class-properties": "^7.16.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "friendsofsymfony/http-cache-bundle": "^2.9",
         "handcraftedinthealps/zendsearch": "^2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.7",
-        "sulu/sulu": "~2.4.8",
+        "sulu/sulu": "~2.4.8@dev",
         "symfony/config": "^5.4",
         "symfony/dotenv": "^5.4",
         "symfony/flex": "^1.17 || ^2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/6934
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use new babel transformer for export namespace from.

#### Why?

Webpack 4 build is failing. Requires: https://github.com/sulu/sulu/pull/6934

