### PR TITLE
Use a valid jwt secret always

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=prod
-APP_SECRET=
+APP_SECRET=s$cretf0rt3st
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 #TRUSTED_HOSTS=localhost,example.com
 ###< symfony/framework-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         ],
         "post-root-package-install": [
             "@php -r \"file_put_contents('.env.local', 'APP_ENV=dev' . PHP_EOL);\"",
-            "@php -r \"file_put_contents('.env', str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
+            "@php -r \"file_put_contents('.env', str_replace('APP_SECRET=s$cretf0rt3st', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
         ],
         "post-create-project-cmd": [
             "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use a valid jwt secret always.

#### Why?

Git clone sulu/skeleton and run it under `stage` and `prod` env will fail as the `APP_SECRET` requires a value for jwt of the two factor bundle. This is only a improvement for ourselves as very project automatically gets a valid secret already on compsoer create-project.

> [2022-12-15T13:37:39.445313+01:00] request.CRITICAL: Exception thrown when handling an exception (Lcobucci\JWT\Signer\InvalidKeyProvided: Key cannot be empty at /private/tmp/release-2-5/vendor/lcobucci/jwt/src/Signer/InvalidKeyProvided.php line 34) {"exception":"[object] (Lcobucci\\JWT\\Signer\\InvalidKeyProvided(code: 0): Key cannot be empty at /private/tmp/release-2-5/vendor/lcobucci/jwt/src/Signer/InvalidKeyProvided.php:34)"} []