### PR TITLE
Fix docker error in new dev secret

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=prod
-APP_SECRET=s$cretf0rt3st
+APP_SECRET='s$cretf0rt3st'
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 #TRUSTED_HOSTS=localhost,example.com
 ###< symfony/framework-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         ],
         "post-root-package-install": [
             "@php -r \"file_put_contents('.env.local', 'APP_ENV=dev' . PHP_EOL);\"",
-            "@php -r \"file_put_contents('.env', str_replace('APP_SECRET=s$cretf0rt3st', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
+            "@php -r \"file_put_contents('.env', str_replace('APP_SECRET=\\'s\\$cretf0rt3st\\'', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
         ],
         "post-create-project-cmd": [
             "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix docker error in new dev secret.

#### Why?

With escaping the secret it will be shown a warning in `docker compose up`:

<img width="615" alt="Bildschirmfoto 2022-12-19 um 23 01 11" src="https://user-images.githubusercontent.com/1698337/208532514-5472e990-5cce-4117-b93f-8d6de3ea8f8d.png">
