### PR TITLE
Allow php-http/discovery as a composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,6 +170,7 @@
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "php-http/discovery": true,
             "symfony/flex": true,
             "symfony/runtime": true,
             "symfony/thanks": true,


### PR DESCRIPTION
Needed after https://github.com/php-http/discovery/releases/tag/1.15.0