### PR TITLE
Support changing the kernel context of the console per ENV

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -21,7 +21,7 @@ if (!\is_file(\dirname(__DIR__) . '/vendor/autoload_runtime.php')) {
 require_once \dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 if (!isset($suluContext)) {
-    $suluContext = Kernel::CONTEXT_ADMIN;
+    $suluContext = \getenv('SULU_CONTEXT') ?: Kernel::CONTEXT_ADMIN;
 }
 
 return function (array $context) use ($suluContext) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR makes it possible to define the kernel context for the console commands per ENV variables.

#### Why?

Symfony provides several debugging commands. For example you can debug the container to list all services with a specified tag. For example

```
bin/console debug:container --tag controller.service_arguments

 -------------------------------------------------------------- -------------------------------------------------------------- 
  Service ID                                                     Class name                                                    
 -------------------------------------------------------------- -------------------------------------------------------------- 
  kernel                                                         App\Kernel                                                    
  App\Controller\Admin\AssociationController                     App\Controller\Admin\AssociationController                    
  Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController   Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController  
 -------------------------------------------------------------- -------------------------------------------------------------- 
```

The problem is that this command would only list the admin controllers. All controllers of the website context will be hidden.

#### Example Usage

To change the kernel context, it will be possible to easily get the services of the website context. This could be done by prefixing the console command with `SULU_CONTEXT=website`

```
SULU_CONTEXT=website bin/console debug:container --tag controller.service_arguments

 -------------------------------------------------------------- -------------------------------------------------------------- 
  Service ID                                                     Class name                                                    
 -------------------------------------------------------------- -------------------------------------------------------------- 
  kernel                                                         App\Kernel                                                    
  App\Controller\Website\RegistrationController                  App\Controller\Website\RegistrationController                 
  Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController   Doctrine\Bundle\DoctrineBundle\Controller\ProfilerController  
  sulu_website.default_controller                                Sulu\Bundle\WebsiteBundle\Controller\DefaultController        
 -------------------------------------------------------------- --------------------------------------------------------------
```

Alternatively you can export the variable to the environment of subsequently executed commands. This will give you the same result as in the above example.

```
export SULU_CONTEXT=website
bin/console debug:container --tag controller.service_arguments
```
