### PR TITLE
Run tests against php 8.2

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -38,7 +38,7 @@ jobs:
                           SULU_ADMIN_EMAIL:
                           DATABASE_URL: "mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=5.7"
 
-                    - php-version: '8.1'
+                    - php-version: '8.2'
                       node-version: '16'
                       npm-version: '6'
                       mysql-version: '8.0'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Run tests against php 8.2.

#### Why?

Currently only PHP 8.1 is tested.
