### PR TITLE
Change phpstan config values to official camelCase parameters

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,5 @@ parameters:
     doctrine:
         objectManagerLoader: tests/phpstan/object-manager.php
     symfony:
-        container_xml_path: %currentWorkingDirectory%/var/cache/website/dev/App_KernelDevDebugContainer.xml
-        console_application_loader: tests/phpstan/console-application.php
+        containerXmlPath: %currentWorkingDirectory%/var/cache/website/dev/App_KernelDevDebugContainer.xml
+        consoleApplicationLoader: tests/phpstan/console-application.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Change phpstan config values to official camelCase parameters

#### Why?


The official documented parameters are camelcase. https://github.com/phpstan/phpstan-symfony