### PR TITLE
Add serve composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,10 @@
             "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",
             "@php bin/adminconsole sulu:admin:info --ansi"
         ],
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php -S 127.0.0.1:8000 -t public config/router.php"
+        ],
         "bootstrap-test-environment": [
             "@php bin/adminconsole doctrine:database:drop --if-exists --force --env test",
             "@php bin/adminconsole doctrine:database:create --env test",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add `serve` composer script to start the development php server.

References in Yii and Mezzio Framework:

 - https://github.com/mezzio/mezzio-skeleton/blob/4f60efe8a5d96b0178d446268c6fc2586f88df6b/composer.json#LL113C11-L117C11
 - https://github.com/yiisoft/app/blob/264163b2af0d90217291a4e5977411173fe72add/composer.json#L12-L15

#### Why?

If a project is using an alternate runner (swoole, roadrunner, ...) the serve script can be adopted to use that one. Also `composer serve` is easier to write then `php -S 127.0.0.1:8000 -t public config/router.php`.

#### Example Usage

```bash
composer serve
```
