### PR TITLE
Force minor version of Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,8 @@
     },
     "extra": {
         "symfony": {
-            "allow-contrib": true
+            "allow-contrib": true,
+            "require": "5.4.*"
         }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/issues/7086, https://github.com/sulu/sulu/issues/7095, https://github.com/symfony/symfony/issues/50617
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Force minor version of Symfony.

#### Why?

Symfony recommends forcing the Symfony Version to keep all packages on the same version. As Sulu should be following the same here like Symfony is doing the in their skeleton:

https://github.com/symfony/skeleton/blob/4b266b2d027e53d952d349eedf14c27263b28744/composer.json#L66

We already had some discussion about this with different partners of Sulu that they also agree here to add this to the Skeleton.
