### PR TITLE
Fix problem with stof extension bundle metadata cache

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -168,6 +168,7 @@ jobs:
             SULU_ADMIN_EMAIL:
             DATABASE_URL: mysql://root:root@127.0.0.1:3306/sulu_test?serverVersion=${{ matrix.mysql-version }}
             COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            LOCK_DSN: flock
 
         strategy:
             fail-fast: false

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "scheb/2fa-bundle": "^6.1",
         "scheb/2fa-email": "^6.1",
         "scheb/2fa-trusted-device": "^6.1",
+        "stof/doctrine-extensions-bundle": "^1.8",
         "sulu/sulu": "~2.5.9",
         "symfony/config": "^6.2",
         "symfony/dotenv": "^6.2",

--- a/config/packages/stof_doctrine_extensions.yaml
+++ b/config/packages/stof_doctrine_extensions.yaml
@@ -2,3 +2,11 @@
 # See the official DoctrineExtensions documentation for more details: https://github.com/doctrine-extensions/DoctrineExtensions/tree/main/doc
 stof_doctrine_extensions:
     default_locale: '%default_locale%'
+
+when@prod: &prod
+    stof_doctrine_extensions:
+        # fix issue with gedmo/extensions 1.8.0 and stof/doctrine-extensions-bundle: 3.12.0
+        # @see https://github.com/stof/StofDoctrineExtensionsBundle/issues/457
+        metadata_cache_pool: doctrine.system_cache_pool
+
+when@stage: *prod


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix problem with stof extension bundle metadata cache.

#### Why?

See https://github.com/stof/StofDoctrineExtensionsBundle/issues/457

2.4 does use https://github.com/antishov/StofDoctrineExtensionsBundle where this config does not exist: https://github.com/sulu/sulu/blob/420acfd192d2ead12189b6863226cf95eede65fe/composer.json#L32
