### PR TITLE
[Rector] Load phpstan doctrine and symfony extension on phpstan.eon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,7 @@
+includes:
+    - vendor/phpstan/phpstan-doctrine/extension.neon
+    - vendor/phpstan/phpstan-symfony/extension.neon
+
 parameters:
     paths:
         - src


### PR DESCRIPTION
@alexander-schranz since Rector no longer magically load phpstan extension, the extension need to be loaded manually.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Since Rector 0.17.13, Rector no longer magically load phpstan extension, the services need to be loaded in the config:

#### Why?

Since Rector 0.17.13, Rector no longer magically load phpstan extension, the services need to be loaded in the config:

- https://github.com/rectorphp/rector-src/pull/4769
