### PR TITLE
Fix issue with rector and new phpstan.dist.neon file

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([__DIR__ . '/src', __DIR__ . '/tests']);
 
     $rectorConfig->phpstanConfigs([
-        __DIR__ . '/phpstan.neon',
+        __DIR__ . '/phpstan.dist.neon',
         // rector does not load phpstan extension automatically so require them manually here:
         __DIR__ . '/vendor/phpstan/phpstan-doctrine/extension.neon',
         __DIR__ . '/vendor/phpstan/phpstan-symfony/extension.neon',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix issue with rector and new phpstan.dist.neon file.

#### Why?

The composer lint currently fails.
