### PR TITLE
Use Github_TOKEN in CI to avoid composer rate limit errors

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -12,8 +12,10 @@ on:
 jobs:
     test:
         name: "PHP ${{ matrix.php-version }} and Node.js ${{ matrix.node-version }}"
-
         runs-on: ubuntu-latest
+
+        env:
+            COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         strategy:
             fail-fast: false
@@ -190,15 +192,14 @@ jobs:
 
     php-windows:
         name: "PHP ${{ matrix.php-version }} and Node.js ${{ matrix.node-version }} on Windows"
-
         runs-on: windows-latest
-
         env:
             APP_ENV: test
             APP_SECRET: a448d1dfcaa563fce56c2fd9981f662b
             MAILER_URL: null://localhost
             SULU_ADMIN_EMAIL:
             DATABASE_URL: mysql://root:root@127.0.0.1:3306/sulu_test?serverVersion=${{ matrix.mysql-version }}
+            COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use Github_TOKEN in CI to avoid composer rate limit errors.

#### Why?

Currently some issues happening on composer git clone:

>  In AuthHelper.php line 132:                                            
>  Could not authenticate against github.com  

![Bildschirmfoto 2024-03-04 um 15 06 09](https://github.com/sulu/skeleton/assets/1698337/1649c76e-c8cf-4ba9-ab59-06353d016641)


