### PR TITLE
Replace not required polyfills for PHP 8.1 and 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,8 @@
         "paragonie/random_compat": "2.*",
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php82": "*",
+        "symfony/polyfill-php81": "*",
         "symfony/polyfill-php80": "*",
         "symfony/polyfill-php74": "*",
         "symfony/polyfill-php73": "*",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Replace not required polyfills for 8.1 and 8.2.

#### Why?

Sulu requires atelast PHP 8.2 so no polyfills for PHP 8.1 or 8.2 functions need to be installed for running Sulu. 