### PR TITLE
Install Jackalope 2 and upgrade to PSR16 cache and make PHPCR Shell available in prod

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -121,6 +121,11 @@ jobs:
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
 
+            - name: Test PHPCR
+              run: bin/console doctrine:phpcr:node:dump /cmf/example/contents --no-interaction
+              env: ${{ matrix.env }}
+              working-directory: ${{ matrix.working-directory }}
+
             - name: Build container
               run: |
                   bin/adminconsole cache:clear --env dev
@@ -235,6 +240,9 @@ jobs:
 
             - name: Build sulu
               run: bin/adminconsole sulu:build dev --no-interaction
+
+            - name: Test PHPCR
+              run: bin/console doctrine:phpcr:node:dump /cmf/example/contents --no-interaction
 
             - name: Build container
               run: |

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -200,7 +200,7 @@ jobs:
                       node-version: '20'
                       npm-version: '10'
                       mysql-version: '8.0'
-                      php-extensions: 'ctype, iconv, intl, mysql, pdo_mysql, php_fileinfo, gd, sodium'
+                      php-extensions: 'ctype, iconv, intl, mysql, pdo_mysql, php_fileinfo, gd, sodium, zip'
                       tools: 'composer:v2'
 
         steps:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -122,7 +122,11 @@ jobs:
               working-directory: ${{ matrix.working-directory }}
 
             - name: Test PHPCR
-              run: bin/console doctrine:phpcr:node:dump /cmf/example/contents --no-interaction
+              run: |
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env dev --no-interaction
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env test --no-interaction
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env stage --no-interaction
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env prod --no-interaction
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
 
@@ -242,7 +246,11 @@ jobs:
               run: bin/adminconsole sulu:build dev --no-interaction
 
             - name: Test PHPCR
-              run: bin/console doctrine:phpcr:node:dump /cmf/example/contents --no-interaction
+              run: |
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env dev --no-interaction
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env test --no-interaction
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env stage --no-interaction
+                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env prod --no-interaction
 
             - name: Build container
               run: |

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -241,23 +241,23 @@ jobs:
                   dependency-versions: 'highest'
 
             - name: Build sulu
-              run: bin/adminconsole sulu:build dev --env dev --no-interaction
+              run: php bin/adminconsole sulu:build dev --env dev --no-interaction
 
             - name: Test phpcr
               run: |
-                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env dev --no-interaction
-                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env prod --no-interaction
+                  php bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env dev --no-interaction
+                  php bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env prod --no-interaction
 
             - name: Build container
               run: |
-                  bin/adminconsole cache:clear --env dev
-                  bin/websiteconsole cache:clear --env dev
-                  bin/adminconsole cache:clear --env test
-                  bin/websiteconsole cache:clear --env test
-                  bin/adminconsole cache:clear --env stage
-                  bin/websiteconsole cache:clear --env stage
-                  bin/adminconsole cache:clear --env prod
-                  bin/websiteconsole cache:clear --env prod
+                  php bin/adminconsole cache:clear --env dev
+                  php bin/websiteconsole cache:clear --env dev
+                  php bin/adminconsole cache:clear --env test
+                  php bin/websiteconsole cache:clear --env test
+                  php bin/adminconsole cache:clear --env stage
+                  php bin/websiteconsole cache:clear --env stage
+                  php bin/adminconsole cache:clear --env prod
+                  php bin/websiteconsole cache:clear --env prod
 
             - name: Lint Code
               run: |
@@ -270,7 +270,7 @@ jobs:
               run: composer test
 
             - name: Test download-language script
-              run: bin/adminconsole sulu:admin:download-language nl
+              run: php bin/adminconsole sulu:admin:download-language nl
 
             - name: Install and configure Node.js
               uses: actions/setup-node@v2

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -117,16 +117,14 @@ jobs:
               working-directory: ${{ matrix.working-directory }}
 
             - name: Build sulu
-              run: bin/adminconsole sulu:build dev --no-interaction
+              run: bin/adminconsole sulu:build dev --env dev --no-interaction
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
 
-            - name: Test PHPCR
+            - name: Test phpcr
               run: |
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env dev --no-interaction
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env test --no-interaction
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env stage --no-interaction
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env prod --no-interaction
+                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env dev --no-interaction
+                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env prod --no-interaction
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
 
@@ -243,14 +241,12 @@ jobs:
                   dependency-versions: 'highest'
 
             - name: Build sulu
-              run: bin/adminconsole sulu:build dev --no-interaction
+              run: bin/adminconsole sulu:build dev --env dev --no-interaction
 
-            - name: Test PHPCR
+            - name: Test phpcr
               run: |
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env dev --no-interaction
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env test --no-interaction
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env stage --no-interaction
-                  bin/console doctrine:phpcr:node:dump /cmf/example/contents --env prod --no-interaction
+                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env dev --no-interaction
+                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env prod --no-interaction
 
             - name: Build container
               run: |

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,9 @@
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "friendsofsymfony/http-cache-bundle": "^2.17",
         "handcraftedinthealps/zendsearch": "^2.1",
-        "jackalope/jackalope-doctrine-dbal": "^1.10",
+        "jackalope/jackalope-doctrine-dbal": "^1.10 || ^2.0",
         "phpcr/phpcr-migrations-bundle": "^1.5",
+        "phpcr/phpcr-shell": "^1.5",
         "scheb/2fa-bundle": "^7.2",
         "scheb/2fa-email": "^7.2",
         "scheb/2fa-trusted-device": "^7.2",
@@ -55,7 +56,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.41",
         "jangregor/phpstan-prophecy": "^1.0",
-        "phpcr/phpcr-shell": "^1.5",
         "phpspec/prophecy-phpunit": "^2.1",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",

--- a/config/packages/sulu_document_manager.yaml
+++ b/config/packages/sulu_document_manager.yaml
@@ -31,8 +31,7 @@ when@prod: &prod
 
     services:
         doctrine_phpcr.meta_cache_provider:
-            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
-            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
+            class: Symfony\Component\Cache\Psr16Cache
             public: false
             arguments:
                 - '@doctrine_phpcr.meta_cache_pool'
@@ -40,8 +39,7 @@ when@prod: &prod
                 - { name: 'kernel.reset', method: 'reset' }
 
         doctrine_phpcr.nodes_cache_provider:
-            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
-            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
+            class: Symfony\Component\Cache\Psr16Cache
             public: false
             arguments:
                 - '@doctrine_phpcr.nodes_cache_pool'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Install Jackalope 2 and make PHPCR Shell available in prod.

#### Why?

Jackalope was not yet update to version 2.

https://github.com/sulu/sulu/blob/2.6/UPGRADE.md#phpcr-and-jackalope-update
