### PR TITLE
Rename example webspace to something more general

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -123,8 +123,8 @@ jobs:
 
             - name: Test phpcr
               run: |
-                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env dev --no-interaction
-                  bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env prod --no-interaction
+                  bin/console doctrine:phpcr:node:dump "/cmf/website/contents" --env dev --no-interaction
+                  bin/console doctrine:phpcr:node:dump "/cmf/website/contents" --env prod --no-interaction
               env: ${{ matrix.env }}
               working-directory: ${{ matrix.working-directory }}
 
@@ -245,8 +245,8 @@ jobs:
 
             - name: Test phpcr
               run: |
-                  php bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env dev --no-interaction
-                  php bin/console doctrine:phpcr:node:dump "/cmf/example/contents" --env prod --no-interaction
+                  php bin/console doctrine:phpcr:node:dump "/cmf/website/contents" --env dev --no-interaction
+                  php bin/console doctrine:phpcr:node:dump "/cmf/website/contents" --env prod --no-interaction
 
             - name: Build container
               run: |

--- a/config/webspaces/website.xml
+++ b/config/webspaces/website.xml
@@ -4,8 +4,8 @@
           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
     <!-- See: http://docs.sulu.io/en/latest/book/webspaces.html how to configure your webspace-->
 
-    <name>example.com</name>
-    <key>example</key>
+    <name>Website</name>
+    <key>website</key>
 
     <localizations>
         <!-- See: http://docs.sulu.io/en/latest/book/localization.html how to add new localizations -->
@@ -36,8 +36,8 @@
 
     <portals>
         <portal>
-            <name>example.com</name>
-            <key>example</key>
+            <name>Website</name>
+            <key>website</key>
 
             <environments>
                 <environment type="prod">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Rename example webspace to something more general.

#### Why?

A more general name avoids hard migrations like renaming a webspace later.

The current webspace is named `example` which forces most to rename it. But mostly we should make the start as easy as possible and go with something which may matches most single webspace installations.

Options which did come to my mind:

 - `general`
 - `main`
 - `website` (other webspaces could be `blog` or `intranet`)
 - `default`
 - `base`

@sulu/core-developer what do you think?
