### PR TITLE
Add lint task for translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -168,7 +168,7 @@
         "lint-twig": "@php bin/console lint:twig templates/",
         "lint-xliff": "@php bin/console lint:xliff translations/",
         "lint-translations": [
-            "@php bin/console debug:translation --all en --only-missing"
+            "@php bin/console debug:translation en --only-missing"
         ],
         "lint-yaml": "@php bin/console lint:yaml config/ --parse-tags",
         "lint-container": [

--- a/composer.json
+++ b/composer.json
@@ -141,6 +141,8 @@
             "@lint-rector",
             "@lint-twig",
             "@lint-yaml",
+            "@lint-xliff",
+            "@lint-translations",
             "@lint-container",
             "@lint-composer",
             "@lint-doctrine"
@@ -164,6 +166,10 @@
         "lint-php-cs": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "lint-composer": "@composer validate --no-check-publish --strict",
         "lint-twig": "@php bin/console lint:twig templates/",
+        "lint-xliff": "@php bin/console lint:xliff translations/",
+        "lint-translations": [
+            "@php bin/console debug:translation --all en --only-missing"
+        ],
         "lint-yaml": "@php bin/console lint:yaml config/ --parse-tags",
         "lint-container": [
             "@php bin/console lint:container --env dev",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/7578, https://github.com/sulu/sulu/pull/7577
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add lint task for translations.

#### Why?

Add a lint task to show which translation where missed when run `composer lint`.

```
bin/console debug:translation en --only-missing
```

#### Todo

 - [x] https://github.com/sulu/sulu/pull/7578