### PR TITLE
Use a shared session cookie between admin and website

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -7,6 +7,7 @@ framework:
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
+        cookie_path: /
         name: SULUSESSID # This avoids conflicts with other applications running on the same domain
 
     #esi: true

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,6 +39,7 @@ security:
                 failure_handler: sulu_security.authentication_handler
             logout:
                 path: sulu_admin.logout
+                # invalidate_session: false # If you have multiple firewalls, you might want to set this to true to only logout of the current firewall
             two_factor:
                 prepare_on_login: true
                 prepare_on_access_denied: true
@@ -62,6 +63,7 @@ security:
        #    logout:
        #        path: logout
        #        target: /
+       #        # invalidate_session: false # If you have multiple firewalls, you might want to set this to true to only logout of the current firewall
        #    remember_me:
        #        secret:   "%kernel.secret%"
        #        lifetime: 604800 # 1 week in seconds

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,7 +39,7 @@ security:
                 failure_handler: sulu_security.authentication_handler
             logout:
                 path: sulu_admin.logout
-                # invalidate_session: false # If you have multiple firewalls, you might want to set this to true to only logout of the current firewall
+                # invalidate_session: false # If you have multiple firewalls, you might want to set this to false to only logout of the current firewall
             two_factor:
                 prepare_on_login: true
                 prepare_on_access_denied: true
@@ -63,7 +63,7 @@ security:
        #    logout:
        #        path: logout
        #        target: /
-       #        # invalidate_session: false # If you have multiple firewalls, you might want to set this to true to only logout of the current firewall
+       #        # invalidate_session: false # If you have multiple firewalls, you might want to set this to false to only logout of the current firewall
        #    remember_me:
        #        secret:   "%kernel.secret%"
        #        lifetime: 604800 # 1 week in seconds


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use a shared session cookie between admin and website.

#### Why?

Depending on which cookies already exists and login into admin after website and other way around you might get logout of the other session. Because session get invalidated by a login.

After some different options and tries with our Partner iCapps (@matthiasseghers) I find sharing the session on the same path and optional document the invalidate_session config is the way to go.

Historically we did put the cookie_path differently to avoid the same issue but it did not work in all cases. Also previously we had 2 different security.yaml and so website yaml didn't know about admin yaml security config and that did force us also different ways. With the way to a single security yaml I also think there speaks nothing against a single session now.

I would also prepare a 3.0 merge request to not longer prepend the `cookie_path` in 3.0 in: https://github.com/sulu/sulu/blob/9ee10853304f2dc39e84a3a91da8e3e193d74391/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php#L182 