### PR TITLE
Fix `composer lint`: phpstan No error to ignore is reported on line 17.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "phpcr/phpcr-shell": "^1.5",
         "phpspec/prophecy-phpunit": "^2.1",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",

--- a/config/router.php
+++ b/config/router.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 // Workaround https://bugs.php.net/64566
 $autoPrependFile = \ini_get('auto_prepend_file');
-// @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7685
 if (false !== (bool) $autoPrependFile && !\in_array(\realpath($autoPrependFile), \get_included_files(), true)) {
     require \ini_get('auto_prepend_file');
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/7655
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | -

#### What's in this PR?

We bump phpstan to ^1.12 and remove a `@phpstan-ignore-next-line` we don't require anymore since phpstan/phpstan#7685 ("Cast to (bool) on string|false !== false should end in non-empty-string") is fixed.

@alexander-schranz Please let me know if we need the bump of phpstan inside of the composer.json or if I should drop the commit and force-push, thanks!

#### To Do

- [ ] Create a documentation PR
- [ ] Create PR for sulu/sulu test skeleton
