### PR TITLE
Remove not longer required travis.php.ini file

### DIFF
--- a/tests/travis.php.ini
+++ b/tests/travis.php.ini
@@ -1,1 +1,0 @@
-memory_limit = 4096M


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove not longer required travis.php.ini file.

#### Why?

Travis is not used since a longer time, the php memory limit is now defined in the github actions files.
