### PR TITLE
Enable no index on stage env always

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -23,3 +23,7 @@ when@test:
         test: true
         session:
             storage_factory_id: session.storage.factory.mock_file
+
+when@stage:
+    framework:
+        disallow_search_engine_index: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Enable no index on stage env always.

#### Why?

Stage envs should never be indexed as they are kind of pre prod environments. Stage does not run under DEBUG mode so this need set manually to avoid indexing the stage pages.