### PR TITLE
Fix falsy .gitignore file when cache:clear fails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,11 +112,11 @@
             "@auto-scripts"
         ],
         "post-root-package-install": [
+            "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",
             "@php -r \"file_put_contents('.env.local', 'APP_ENV=dev' . PHP_EOL);\"",
             "@php -r \"file_put_contents('.env', str_replace('APP_SECRET=\\'s\\$cretf0rt3st\\'', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
         ],
         "post-create-project-cmd": [
-            "@php -r \"file_put_contents('.gitignore', str_replace(['composer.lock' . PHP_EOL, 'symfony.lock' . PHP_EOL, 'package-lock.json' . PHP_EOL], ['', '', ''], file_get_contents('.gitignore')));\"",
             "@php bin/adminconsole sulu:admin:info --ansi"
         ],
         "bootstrap-test-environment": [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Avoid falsely .gitignore file when cache:clear fails.

#### Why?

Currently there is a bug https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/639. As the `auto-scripts` with cache:clear all called before the `gitignore` script the gitignore is not modified correctly and ends in having the composer.lock, symfony.lock and package-lock.json file still excluded. To avoid this we move the scripts to the `post-root-package-install` where we already modify the .env files.
