### PR TITLE
`bin/console` to ask `composer` where vendor dir is

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -14,15 +14,17 @@ declare(strict_types=1);
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
-if (!\is_dir(\dirname(__DIR__) . '/vendor')) {
+$vendorDir = exec('composer config vendor-dir');
+
+if (!\is_dir($vendorDir)) {
     throw new \LogicException('Dependencies are missing. Try running "composer install".');
 }
 
-if (!\is_file(\dirname(__DIR__) . '/vendor/autoload_runtime.php')) {
+if (!\is_file($vendorDir.'/autoload_runtime.php')) {
     throw new \LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
 }
 
-require_once \dirname(__DIR__) . '/vendor/autoload_runtime.php';
+require_once $vendorDir.'/autoload_runtime.php';
 
 if (!isset($suluContext)) {
     $suluContext = Kernel::CONTEXT_ADMIN;

--- a/bin/console.php
+++ b/bin/console.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 $vendorDir = exec('composer config vendor-dir');
 
 if (!\is_dir($vendorDir)) {
-    throw new \LogicException('Dependencies are missing. Try running "composer install".');
+    throw new \LogicException('Dependencies are missing from vendor directory "'.$vendorDir.'". Try running "composer install".');
 }
 
 if (!\is_file($vendorDir.'/autoload_runtime.php')) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

I am not sure it's the best way to solve this issue. I applied the same way `composer` [solved this](https://github.com/composer/composer/blob/6308749a610ea661e549807b28b946ef29ecd377/bin/compile#L7).

#### What's in this PR?

`bin/console.php` asks `composer` where to find code dependencies.

#### Why?

I like to work with vendor being outside my source code. Handy for having it in a Docker volume.

I changed the error message as I did't understand why it couldn't find `ext-*` dependencies or dependencies that `composer` just installed.

#### To Do

- [ ] Create a documentation PR
- [ ] Create PR for sulu/sulu test skeleton
