### PR TITLE
Add missing 6.4 update files

### DIFF
--- a/config/routes/security.yaml
+++ b/config/routes/security.yaml
@@ -1,0 +1,4 @@
+# Not in use currently for sulu:
+#_security_logout:
+#    resource: security.route_loader.logout
+#    type: service


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add missing 6.4 update files, which Symfony Flex automatically creates.

#### Why?

We are not updating all 6.4 recipe files as that is targeted in 2.6 branch already, but this files were created by flex and we need comment out the security routes as they are not used by us. Same as we did on 2.6 here: https://github.com/sulu/skeleton/pull/238
