### PR TITLE
Change resource_locator to route property

### DIFF
--- a/config/templates/pages/default.xml
+++ b/config/templates/pages/default.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Changes the url property type for the page templates from `resource_locator` to `route`.

#### Why?

The route generation is not working on the `resource_locator` and in the Sulu 3.0 final release, we will get rid of the `resource_locator`.