### PR TITLE
Upgrade doctrine fixtures bundle to 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/doctrine-bundle": "^2.13",
-        "doctrine/doctrine-fixtures-bundle": "^3.6",
+        "doctrine/doctrine-fixtures-bundle": "^3.6 || ^4.0",
         "friendsofsymfony/http-cache-bundle": "^3.0",
         "handcraftedinthealps/zendsearch": "^2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.10 || ^2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/7161
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Upgrade doctrine fixtures to 4.

#### Why?

Seems like it was not yet allowed in skeleton but in sulu/sulu.