### PR TITLE
Allow PHPUnit 12 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^11.5 || ^12.1",
         "rector/rector": "^2.0",
         "sulu/sulu-rector": "^2.0",
         "symfony/browser-kit": "^7.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Allow also installation of PHPUnit 12

#### Why?

Allow also PHPUnit 12. We can not ship directly PHPUnit 12 as we still support PHP 8.2 and so we keep the constraint open with 11 and 12.