### PR TITLE
Remove not longer required RestRoutingBundle

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -9,7 +9,6 @@ return [
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],
     Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle::class => ['all' => true],
     FOS\RestBundle\FOSRestBundle::class => ['all' => true],
-    HandcraftedInTheAlps\RestRoutingBundle\RestRoutingBundle::class => ['all' => true],
     JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
     Massive\Bundle\SearchBundle\MassiveSearchBundle::class => ['all' => true],
     FOS\HttpCacheBundle\FOSHttpCacheBundle::class => ['all' => true],

--- a/symfony.lock
+++ b/symfony.lock
@@ -82,9 +82,6 @@
             "config/packages/fos_rest.yaml"
         ]
     },
-    "handcraftedinthealps/rest-routing-bundle": {
-        "version": "1.1.1"
-    },
     "jms/serializer-bundle": {
         "version": "5.4",
         "recipe": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

On 2.6 the rest routing bundle is optional. On 3.0 we removed it so we can remove it from the skeleton.

#### Why?

Follow up of https://github.com/sulu/skeleton/pull/286