### PR TITLE
Update web profiler and framework bundle recipe updates

### DIFF
--- a/config/packages/web_profiler.yaml
+++ b/config/packages/web_profiler.yaml
@@ -8,4 +8,6 @@ when@dev:
 
 when@test:
     framework:
-        profiler: { collect: false }
+        profiler:
+            collect: false
+            collect_serializer_data: true

--- a/symfony.lock
+++ b/symfony.lock
@@ -372,7 +372,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "7.3",
-            "ref": "5b2b543e13942495c0003f67780cb4448af9e606"
+            "ref": "a363460c1b0b4a4d0242f2ce1a843ca0f6ac9026"
         },
         "files": [
             "config/packages/web_profiler.yaml",

--- a/symfony.lock
+++ b/symfony.lock
@@ -240,7 +240,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "7.3",
-            "ref": "a64726446f6dcf3721f192c1df35418d69b3ba92"
+            "ref": "5a1497d539f691b96afd45ae397ce5fe30beb4b9"
         },
         "files": [
             ".editorconfig",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Update web profiler and framework bundle recipe updates.

#### Why?

New recipe versions are available.

#### Unchanged

⚠️ I did not apply the recommended change to not longer generate the `APP_SECRET` in the `.env` file. While this sure make sense it would be require a good documentation that now the Hosters and OP Teams need to define the APP_SECRET in the .env.local or via own ENV var. Also if the kernel.secret is used for encryption and decryption it maybe make issues if you sync databases between stage and prod envs if its not the same. So I currently keep our old APP_SECRET handling. We still should apply the changes for 3.0 version to be still as near to Symfony as possible, but for 2.6 I think its a to hard change. /cc @sulu/core-developer 