### PR TITLE
Update Symfony recipes with correct deprecationTrigger

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -33,6 +33,8 @@
         </include>
 
         <deprecationTrigger>
+            <method>Doctrine\Deprecations\Deprecation::trigger</method>
+            <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
             <function>trigger_deprecation</function>
         </deprecationTrigger>
     </source>

--- a/symfony.lock
+++ b/symfony.lock
@@ -18,7 +18,7 @@
         }
     },
     "doctrine/doctrine-bundle": {
-        "version": "2.14",
+        "version": "2.16",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -32,7 +32,7 @@
         ]
     },
     "doctrine/doctrine-fixtures-bundle": {
-        "version": "3.6",
+        "version": "4.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -56,7 +56,7 @@
         ]
     },
     "friendsofsymfony/http-cache-bundle": {
-        "version": "3.0.1"
+        "version": "3.2.0"
     },
     "friendsofsymfony/jsrouting-bundle": {
         "version": "3.5",
@@ -71,7 +71,7 @@
         ]
     },
     "friendsofsymfony/rest-bundle": {
-        "version": "3.7",
+        "version": "3.8",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "main",
@@ -83,10 +83,10 @@
         ]
     },
     "handcraftedinthealps/rest-routing-bundle": {
-        "version": "1.1.1"
+        "version": "1.2.0"
     },
     "jms/serializer-bundle": {
-        "version": "5.4",
+        "version": "5.5",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "main",
@@ -98,13 +98,13 @@
         ]
     },
     "massive/build-bundle": {
-        "version": "0.5.7"
+        "version": "0.5.9"
     },
     "massive/search-bundle": {
-        "version": "2.9.1"
+        "version": "2.9.4"
     },
     "php-cs-fixer/shim": {
-        "version": "3.60",
+        "version": "3.87",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -116,7 +116,7 @@
         ]
     },
     "php-http/discovery": {
-        "version": "1.19",
+        "version": "1.20",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -131,7 +131,7 @@
         "version": "1.6.0"
     },
     "phpstan/phpstan": {
-        "version": "1.11",
+        "version": "2.1",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "main",
@@ -143,7 +143,7 @@
         ]
     },
     "phpunit/phpunit": {
-        "version": "11.5",
+        "version": "12.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -152,13 +152,13 @@
         },
         "files": [
             ".env.test",
-            "bin/phpunit",
-            "phpunit.xml.dist",
-            "tests/bootstrap.php"
+            "phpunit.dist.xml",
+            "tests/bootstrap.php",
+            "bin/phpunit"
         ]
     },
     "scheb/2fa-bundle": {
-        "version": "7.5",
+        "version": "7.11",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -171,7 +171,7 @@
         ]
     },
     "stof/doctrine-extensions-bundle": {
-        "version": "1.12",
+        "version": "1.14",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "main",
@@ -183,10 +183,10 @@
         ]
     },
     "symfony-cmf/routing-bundle": {
-        "version": "3.1.0"
+        "version": "3.1.1"
     },
     "symfony/console": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -198,7 +198,7 @@
         ]
     },
     "symfony/debug-bundle": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -210,7 +210,7 @@
         ]
     },
     "symfony/flex": {
-        "version": "2.4",
+        "version": "2.8",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -223,7 +223,7 @@
         ]
     },
     "symfony/form": {
-        "version": "7.2",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -243,7 +243,6 @@
             "ref": "5a1497d539f691b96afd45ae397ce5fe30beb4b9"
         },
         "files": [
-            ".editorconfig",
             "config/packages/cache.yaml",
             "config/packages/framework.yaml",
             "config/preload.php",
@@ -251,11 +250,12 @@
             "config/services.yaml",
             "public/index.php",
             "src/Controller/.gitignore",
-            "src/Kernel.php"
+            "src/Kernel.php",
+            ".editorconfig"
         ]
     },
     "symfony/lock": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -267,7 +267,7 @@
         ]
     },
     "symfony/mailer": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -303,7 +303,7 @@
         ]
     },
     "symfony/routing": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -316,7 +316,7 @@
         ]
     },
     "symfony/security-bundle": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -329,7 +329,7 @@
         ]
     },
     "symfony/translation": {
-        "version": "7.2",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -342,7 +342,7 @@
         ]
     },
     "symfony/twig-bundle": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -355,7 +355,7 @@
         ]
     },
     "symfony/validator": {
-        "version": "7.1",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -380,7 +380,7 @@
         ]
     },
     "vincentlanglet/twig-cs-fixer": {
-        "version": "3.5",
+        "version": "3.9",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "main",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Reinstall the recipes. From time to time its better todo again a:

```bash
rm symfony.lock
composer update
```

To check what happens without a symfony.lock file. To apply some maybe skipped suggestions of the past. Not sure why sometimes suggestions like this one are skipped when run `composer recipes:update`

#### Why?

Keep suggestions uptodate.