### PR TITLE
Update symfony/routing recipe to define DEFAULT_URI

### DIFF
--- a/.env
+++ b/.env
@@ -32,6 +32,12 @@ LOCK_DSN=flock
 MAILER_DSN=null://null
 ###< symfony/mailer ###
 
+###> symfony/routing ###
+# Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
+# See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
+DEFAULT_URI=http://localhost
+###< symfony/routing ###
+
 ###> doctrine/phpcr-bundle ###
 ###< doctrine/phpcr-bundle ###
 

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -2,7 +2,7 @@ framework:
     router:
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(DEFAULT_URI)%'
 
 when@prod: &prod
     framework:

--- a/symfony.lock
+++ b/symfony.lock
@@ -308,7 +308,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "7.0",
-            "ref": "21b72649d5622d8f7da329ffb5afb232a023619d"
+            "ref": "ab1e60e2afd5c6f4a6795908f646e235f2564eb2"
         },
         "files": [
             "config/packages/routing.yaml",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Update symfony/routing recipe.

#### Why?

New recipe provided by Symfony. The latest version of Symfony CLI also defines the DEFAULT_URI for local development.

Having this as ENV variable make it easier for OP team configure cronjobs.