### PR TITLE
Add json response for maintainance mode

### DIFF
--- a/public/maintenance.php
+++ b/public/maintenance.php
@@ -2,7 +2,7 @@
 // default locale for maintenance translations
 \define('DEFAULT_LOCALE', 'en');
 
-// allow acces for following ips
+// allow access for following ips
 $allowedIPs = [
     '127.0.0.1',
 ];
@@ -27,13 +27,30 @@ if (\in_array($_SERVER['REMOTE_ADDR'], $allowedIPs, true)) {
 }
 
 // get language
-$lang = \substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+$lang = \substr($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '', 0, 2); // @phpstan-ignore-line argument.type
 
 // chose locale
 $locale = \array_key_exists($lang, $translations) ? $lang : DEFAULT_LOCALE;
 
-\header('Content-Type: text/html; charset=utf-8');
 \http_response_code(503);
+\header('Content-Language: ' . $locale);
+
+if (isset($_SERVER['HTTP_ACCEPT'])
+    && 1 === \preg_match('#^application/(.+\+)?json$#', $_SERVER['HTTP_ACCEPT'])
+) {
+    \header('Content-Type: application/problem+json; charset=utf-8');
+    \http_response_code(503);
+
+    echo \json_encode([
+        'type' => 'https://tools.ietf.org/html/rfc7807',
+        'title' => $translations[$locale]['title'],
+        'detail' => $translations[$locale]['heading'] . \PHP_EOL . \PHP_EOL . $translations[$locale]['description'],
+    ], \JSON_THROW_ON_ERROR);
+
+    exit;
+}
+
+\header('Content-Type: text/html; charset=utf-8');
 
 ?><!doctype html>
 <html lang="<?php echo $locale; ?>">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add json response for maintainance mode.

#### Why?

In the headless setups / json requests we also should handle the requests.