### PR TITLE
Use MySQL 8.4 by default

### DIFF
--- a/.env
+++ b/.env
@@ -46,7 +46,7 @@ DEFAULT_URI=http://localhost
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
-DATABASE_URL="mysql://root:ChangeMe@127.0.0.1:3306/su_myapp?serverVersion=8.0.32&charset=utf8mb4"
+DATABASE_URL="mysql://root:ChangeMe@127.0.0.1:3306/su_myapp?serverVersion=8.4.7&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
 ###< doctrine/doctrine-bundle ###

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -87,7 +87,7 @@ jobs:
                           APP_SECRET: a448d1dfcaa563fce56c2fd9981f662b
                           MAILER_URL: null://localhost
                           SULU_ADMIN_EMAIL:
-                          DATABASE_URL: "mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=8.4"
+                          DATABASE_URL: "mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=8.4.7"
 
         services:
             mysql:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,8 +3,7 @@ version: '3'
 services:
 ###> doctrine/doctrine-bundle ###
   database:
-    # arm compatible mysql docker image
-    image: mysql/mysql-server:${MYSQL_VERSION:-8.0} # arm and x86/x64 compatible mysql image
+    image: mysql:${MYSQL_VERSION:-8.4}
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-su_myapp}
       # You should definitely change the password in production

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -4,7 +4,7 @@ doctrine:
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '8.0.27'
+        #server_version: '8.4.7'
 
         profiling_collect_backtrace: '%kernel.debug%'
         use_savepoints: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/8436#event-21383761944
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use MySQL 8.4 by default.

#### Why?

New LTS version of MySQL should be used by default.