### PR TITLE
Allow installation of Symfony Monolog Bundle 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "symfony/framework-bundle": "^7.4",
         "symfony/mailer": "^7.4",
         "symfony/monolog-bridge": "^7.4",
-        "symfony/monolog-bundle": "^3.4",
+        "symfony/monolog-bundle": "^4.0",
         "symfony/runtime": "^7.4",
         "symfony/security-bundle": "^7.4",
         "symfony/twig-bundle": "^7.4"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/8441
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Allow installation of Symfony Monolog Bundle 4.

#### Why?

Prepare Symfony 8 support.