### PR TITLE
Support Monolog 4 Bundle in 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "symfony/framework-bundle": "^7.4",
         "symfony/mailer": "^7.4",
         "symfony/monolog-bridge": "^7.4",
-        "symfony/monolog-bundle": "^3.4",
+        "symfony/monolog-bundle": "^4.0",
         "symfony/runtime": "^7.4",
         "symfony/security-bundle": "^7.4",
         "symfony/twig-bundle": "^7.4"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/skeleton/pull/317
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Support Monolog 4 Bundle in 2.6.

#### Why?

Even we will not support Symfony 8 in 2.6 it make sense still use already Monolog 4 Symfony Bundle as that is compatible to 7.4 also. 