### PR TITLE
Symfony recipes update

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,7 +9,10 @@ $finder = (new Finder())
     ->in(__DIR__)
     ->ignoreDotFiles(false)
     ->exclude('var')
-    ->notName('bundles.php');
+    ->notPath([
+        'config/bundles.php',
+        'config/reference.php',
+    ]);
 
 return (new Config())
     ->setRiskyAllowed(true)

--- a/symfony.lock
+++ b/symfony.lock
@@ -347,7 +347,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "6.4",
-            "ref": "cab5fd2a13a45c266d45a7d9337e28dee6272877"
+            "ref": "f250159ebe99153d0c640a3e7742876fc7453f2c"
         },
         "files": [
             "config/packages/twig.yaml",

--- a/symfony.lock
+++ b/symfony.lock
@@ -109,7 +109,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "3.0",
-            "ref": "16422bf8eac6c3be42afe07d37e2abc89d2bdf6b"
+            "ref": "6cf95ac1baa3d6f5816dd4db7281997912f239a6"
         },
         "files": [
             ".php-cs-fixer.dist.php"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Symfony recipes update.

#### Why?

Update recipe and skip one recipe which fetches third party JS which I don't agree currently be added to the Sulu core https://github.com/symfony/recipes/pull/1526