### PR TITLE
Add Doctrine migrations bundle to skeleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "cmsig/seal-loupe-adapter": "^0.12.2",
         "doctrine/doctrine-bundle": "^2.13",
         "doctrine/doctrine-fixtures-bundle": "^3.6 || ^4.0",
+        "doctrine/doctrine-migrations-bundle": "^3.3",
         "friendsofsymfony/http-cache-bundle": "^3.0",
         "scheb/2fa-bundle": "^7.3",
         "scheb/2fa-email": "^7.3",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -45,4 +45,5 @@ return [
     Sulu\Search\Infrastructure\Symfony\HttpKernel\SuluSearchBundle::class => ['all' => true],
     Sulu\CustomUrl\Infrastructure\Symfony\HttpKernel\SuluCustomUrlBundle::class => ['all' => true],
     CmsIg\Seal\Integration\Symfony\SealBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
 ];

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,6 @@
+doctrine_migrations:
+    migrations_paths:
+        # namespace is arbitrary but should be different from App\Migrations
+        # as migrations classes should NOT be autoloaded
+        'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    enable_profiler: false

--- a/symfony.lock
+++ b/symfony.lock
@@ -47,6 +47,19 @@
             "src/DataFixtures/AppFixtures.php"
         ]
     },
+    "doctrine/doctrine-migrations-bundle": {
+        "version": "3.7",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.1",
+            "ref": "1d01ec03c6ecbd67c3375c5478c9a423ae5d6a33"
+        },
+        "files": [
+            "config/packages/doctrine_migrations.yaml",
+            "migrations/.gitignore"
+        ]
+    },
     "friendsofsymfony/http-cache-bundle": {
         "version": "3.3.0"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The skeleton now requires the Doctrine migrations bundle with the same minimum version supported by Sulu. The bundle is registered in the kernel bundle list. The default Symfony Flex configuration is added for project migrations.

#### Why?

Sulu uses the Doctrine migration bundle for future content migrations, therefore new Sulu projects should include the standard Doctrine migration setup out of the box. This lets projects create and run database migrations without adding the bundle manually. The dependency constraint stays aligned with the Sulu minimum.